### PR TITLE
Fix wake commands and restore app-aware writing

### DIFF
--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -347,7 +347,15 @@ Selected text: \(selectedText ?? "None")
         if screenshotAvailable {
             return "Could not reliably infer a two-sentence summary for \(activeApp) from the screenshot and metadata."
         }
-        return "Could not reliably infer a two-sentence summary for \(activeApp) from the visible metadata."
+        let writingContext = AppWritingContext.classify(
+            appName: appName,
+            bundleIdentifier: bundleIdentifier,
+            windowTitle: windowTitle
+        )
+        let selectionHint = selectedText?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            ? " Nearby selected text is available as a tone and spelling hint."
+            : ""
+        return "The user is writing in \(activeApp), treated as \(writingContext.label).\(selectionHint)"
     }
 
     private func focusedWindowTitle(from appElement: AXUIElement) -> String? {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2596,6 +2596,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 let result = try await AppleFoundationModelsPostProcessor.shared.executeCommand(
                     command,
                     appName: context.appName,
+                    bundleIdentifier: context.bundleIdentifier,
                     windowTitle: context.windowTitle,
                     contextSummary: context.contextSummary,
                     selectedText: context.selectedText,
@@ -2654,6 +2655,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             let request = SmartCleanupRequest(
                 transcript: trimmedRawTranscript,
                 appName: context.appName,
+                bundleIdentifier: context.bundleIdentifier,
                 windowTitle: context.windowTitle,
                 selectedText: context.selectedText,
                 contextSummary: context.contextSummary,

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -385,7 +385,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
     private var speechRecognitionVocabulary: String {
         guard wakeCommandsEnabled else { return dictionaryVocabulary }
-        return [dictionaryVocabulary, "Hey Megaphone", "Megaphone"]
+        return ([dictionaryVocabulary] + WakePhraseMatcher.recognitionHints)
             .filter { !$0.isEmpty }
             .joined(separator: "\n")
     }

--- a/Sources/AppleFoundationModelsPostProcessor.swift
+++ b/Sources/AppleFoundationModelsPostProcessor.swift
@@ -31,6 +31,7 @@ struct SmartCleanupRequest: Sendable {
     }
     let transcript: String
     let appName: String?
+    let bundleIdentifier: String?
     let windowTitle: String?
     let selectedText: String?
     let contextSummary: String
@@ -38,6 +39,81 @@ struct SmartCleanupRequest: Sendable {
     let corrections: [Correction]
     let outputLanguage: String
     let customInstructions: String
+}
+
+enum AppWritingContext: String, Equatable, Sendable {
+    case email
+    case workChat
+    case casualChat
+    case document
+    case codeOrTerminal
+    case neutral
+
+    static func classify(
+        appName: String?,
+        bundleIdentifier: String?,
+        windowTitle: String?
+    ) -> AppWritingContext {
+        let app = appName?.lowercased() ?? ""
+        let bundle = bundleIdentifier?.lowercased() ?? ""
+        let title = windowTitle?.lowercased() ?? ""
+        let identity = "\(app) \(bundle)"
+        let all = "\(identity) \(title)"
+
+        if identity.contains("slack") || identity.contains("msteams") || identity.contains("microsoft teams") {
+            return .workChat
+        }
+        if identity.contains("discord") || bundle.contains("com.apple.mobilesms") || app == "messages" {
+            return .casualChat
+        }
+        if bundle.contains("com.apple.mail") || identity.contains("outlook") || all.contains("gmail") {
+            return .email
+        }
+        let codeApps = [
+            "terminal", "iterm", "ghostty", "warp", "xcode", "visual studio code",
+            "vscode", "cursor", "zed"
+        ]
+        if codeApps.contains(where: identity.contains) {
+            return .codeOrTerminal
+        }
+        let documentApps = ["pages", "notes", "obsidian", "notion", "microsoft word"]
+        if documentApps.contains(where: identity.contains) || title.contains("google docs") {
+            return .document
+        }
+        return .neutral
+    }
+
+    var label: String {
+        switch self {
+        case .email: return "email"
+        case .workChat: return "work chat"
+        case .casualChat: return "casual chat"
+        case .document: return "document"
+        case .codeOrTerminal: return "code or terminal"
+        case .neutral: return "general writing"
+        }
+    }
+
+    var cleanupGuidance: String {
+        switch self {
+        case .email:
+            return "Use readable email punctuation and paragraph breaks. Do not invent a greeting, sign-off, subject, or details."
+        case .workChat:
+            return "Use concise, professional chat formatting. Preserve the speaker's tone and do not make the message more formal unless asked."
+        case .casualChat:
+            return "Use natural conversational punctuation and preserve the speaker's casual tone."
+        case .document:
+            return "Use polished prose punctuation and paragraph breaks while preserving every idea and the speaker's tone."
+        case .codeOrTerminal:
+            return "Preserve commands, code, flags, paths, identifiers, line breaks, and technical formatting exactly when clear."
+        case .neutral:
+            return "Use neutral, readable punctuation and preserve the speaker's tone."
+        }
+    }
+
+    var commandGuidance: String {
+        "When the request does not specify a style, shape the result for \(label). \(cleanupGuidance) An explicit style request always wins."
+    }
 }
 
 struct SmartCleanupResponse: Sendable {
@@ -114,7 +190,7 @@ actor AppleFoundationModelsPostProcessor {
             session = makeSession(instructions: Self.instructions)
         }
 
-        let prompt = Self.prompt(for: request)
+        let prompt = Self.cleanupPrompt(for: request)
         let started = ContinuousClock.now
         let responseText = try await respond(session: session, prompt: prompt, timeout: timeout)
         let elapsed = started.duration(to: .now).timeInterval
@@ -170,6 +246,7 @@ actor AppleFoundationModelsPostProcessor {
     func executeCommand(
         _ command: String,
         appName: String?,
+        bundleIdentifier: String?,
         windowTitle: String?,
         contextSummary: String,
         selectedText: String?,
@@ -190,6 +267,7 @@ actor AppleFoundationModelsPostProcessor {
         let prompt = Self.commandPrompt(
             command: trimmed,
             appName: appName,
+            bundleIdentifier: bundleIdentifier,
             windowTitle: windowTitle,
             contextSummary: contextSummary,
             selectedText: selectedText,
@@ -197,8 +275,9 @@ actor AppleFoundationModelsPostProcessor {
             vocabulary: vocabulary
         )
         let started = ContinuousClock.now
-        let output = try await respond(session: session, prompt: prompt, timeout: timeout)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let output = Self.normalizeCommandOutput(
+            try await respond(session: session, prompt: prompt, timeout: timeout)
+        )
         guard !output.isEmpty else { throw SmartCleanupError.emptyOutput }
         return SmartCleanupResponse(
             text: output,
@@ -210,6 +289,7 @@ actor AppleFoundationModelsPostProcessor {
     static func commandPrompt(
         command: String,
         appName: String?,
+        bundleIdentifier: String?,
         windowTitle: String?,
         contextSummary: String,
         selectedText: String?,
@@ -220,7 +300,17 @@ actor AppleFoundationModelsPostProcessor {
             ? ""
             : "Preferred spellings: \(vocabulary.prefix(40).joined(separator: ", "))\n"
         let appHint = appName.map { "Destination app: \($0.prefix(100))\n" } ?? ""
+        let bundleHint = bundleIdentifier.map { "Destination bundle: \($0.prefix(160))\n" } ?? ""
         let windowHint = windowTitle.map { "Window: \($0.prefix(160))\n" } ?? ""
+        let writingContext = AppWritingContext.classify(
+            appName: appName,
+            bundleIdentifier: bundleIdentifier,
+            windowTitle: windowTitle
+        )
+        let writingHint = """
+        Writing context: \(writingContext.label)
+        App-aware guidance: \(writingContext.commandGuidance)
+        """
         let contextHint = contextSummary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             ? ""
             : "Context: \(contextSummary.prefix(800))\n"
@@ -239,7 +329,8 @@ actor AppleFoundationModelsPostProcessor {
             """ }
             ?? ""
         let prompt = """
-        \(appHint)\(windowHint)\(contextHint)\(selectedTextHint)\(vocabularyHint)\(previousTextHint)SPOKEN REQUEST:
+        \(appHint)\(bundleHint)\(windowHint)\(writingHint)
+        \(contextHint)\(selectedTextHint)\(vocabularyHint)\(previousTextHint)SPOKEN REQUEST:
         <request>
         \(command.trimmingCharacters(in: .whitespacesAndNewlines))
         </request>
@@ -304,7 +395,7 @@ actor AppleFoundationModelsPostProcessor {
         }
     }
 
-    private static func prompt(for request: SmartCleanupRequest) -> String {
+    static func cleanupPrompt(for request: SmartCleanupRequest) -> String {
         var hints: [String] = []
         if let app = request.appName?.trimmingCharacters(in: .whitespacesAndNewlines), !app.isEmpty {
             hints.append("Destination app: \(app.prefix(100))")
@@ -312,6 +403,13 @@ actor AppleFoundationModelsPostProcessor {
         if let title = request.windowTitle?.trimmingCharacters(in: .whitespacesAndNewlines), !title.isEmpty {
             hints.append("Window title (spelling/formatting hint only): \(title.prefix(160))")
         }
+        let writingContext = AppWritingContext.classify(
+            appName: request.appName,
+            bundleIdentifier: request.bundleIdentifier,
+            windowTitle: request.windowTitle
+        )
+        hints.append("Writing context: \(writingContext.label)")
+        hints.append("App-aware cleanup: \(writingContext.cleanupGuidance)")
         if let selected = request.selectedText?.trimmingCharacters(in: .whitespacesAndNewlines), !selected.isEmpty {
             hints.append("Nearby selected text (spelling/tone hint only): \(selected.prefix(300))")
         }

--- a/Sources/AppleFoundationModelsPostProcessor.swift
+++ b/Sources/AppleFoundationModelsPostProcessor.swift
@@ -65,7 +65,7 @@ actor AppleFoundationModelsPostProcessor {
     Treat the selected text as the only source material and the spoken command as the requested transformation. Preserve the original language unless translation is explicitly requested. Do not answer unrelated questions or invent unrelated content.
     """
     private static let commandInstructions = """
-    Fulfill the user's spoken request. Return only the useful result, with no preamble, explanation, or quotation marks unless the user asks for them. Be concise by default. Use application context only when it helps interpret the request. When recent inserted text is provided, resolve references such as “that,” “it,” “the last sentence,” or requests to rewrite, format, shorten, expand, or change tone against that text. Never claim to perform actions outside this response; produce the text the user asked for instead.
+    Fulfill the user's spoken request. Return only the useful result, with no preamble, explanation, or quotation marks unless the user asks for them. Never wrap the result in XML or HTML tags such as <response>. Be concise by default. Use application context only when it helps interpret the request. When recent inserted text is provided, resolve references such as “that,” “it,” “the last sentence,” or requests to rewrite, format, shorten, expand, or change tone against that text. Never claim to perform actions outside this response; produce the text the user asked for instead.
     """
 
     private let model = SystemLanguageModel(
@@ -156,8 +156,9 @@ actor AppleFoundationModelsPostProcessor {
         </command>
         """
         let started = ContinuousClock.now
-        let output = try await respond(session: session, prompt: prompt, timeout: timeout)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let output = Self.normalizeCommandOutput(
+            try await respond(session: session, prompt: prompt, timeout: timeout)
+        )
         try Self.validate(output, source: selectedText, allowsExpansion: true)
         return SmartCleanupResponse(
             text: output,
@@ -244,6 +245,24 @@ actor AppleFoundationModelsPostProcessor {
         </request>
         """
         return prompt
+    }
+
+    static func normalizeCommandOutput(_ raw: String) -> String {
+        var value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let options: String.CompareOptions = [.regularExpression, .caseInsensitive]
+
+        while !value.isEmpty {
+            let before = value
+            if let opening = value.range(of: #"^<response\s*>\s*"#, options: options) {
+                value.removeSubrange(opening)
+            }
+            if let closing = value.range(of: #"\s*</response\s*>$"#, options: options) {
+                value.removeSubrange(closing)
+            }
+            value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            if value == before { break }
+        }
+        return value
     }
 
     private func makeSession(instructions: String) -> LanguageModelSession {

--- a/Sources/WakePhraseMatcher.swift
+++ b/Sources/WakePhraseMatcher.swift
@@ -63,9 +63,25 @@ struct WakePhraseMatcher {
         if let match = match(pattern: heyPattern, phrase: .heyMegaphone, in: transcript) {
             return match
         }
+        // SpeechAnalyzer occasionally drops the quiet leading “Hey” while
+        // still returning the distinctive segmented product name. Recover
+        // only “mega phone” here; broader acoustic aliases stay Hey-gated.
+        if let match = match(pattern: segmentedRecoveryPattern, phrase: .heyMegaphone, in: transcript) {
+            return match
+        }
         guard plainMegaphoneEnabled else { return nil }
         return match(pattern: plainPattern, phrase: .megaphone, in: transcript)
     }
+
+    static let recognitionHints = [
+        "Hey Megaphone",
+        "Megaphone",
+        "Hey Mega Phone",
+        "Hey Make a Phone",
+        "Hey Made a Phone",
+        "Hey Mega Foam",
+        "Hey Mega Form"
+    ]
 
     private func cooldownHasElapsed(at date: Date) -> Bool {
         guard let lastMatchDate else { return true }
@@ -106,6 +122,9 @@ struct WakePhraseMatcher {
         "mega" + phraseSeparator + "foam",
         "mega" + phraseSeparator + "form",
         "mega" + phraseSeparator + "phoned",
+        "megafone",
+        "megafoam",
+        "megaform",
         "megha" + phraseSeparator + "phone",
         "mecca" + phraseSeparator + "phone",
         "mecha" + phraseSeparator + "phone",
@@ -130,7 +149,11 @@ struct WakePhraseMatcher {
         options: [.caseInsensitive]
     )
     private static let plainPattern = try! NSRegularExpression(
-        pattern: leadingSeparators + strictMegaphoneVariants + phraseBoundary,
+        pattern: leadingSeparators + "megaphone" + phraseBoundary,
+        options: [.caseInsensitive]
+    )
+    private static let segmentedRecoveryPattern = try! NSRegularExpression(
+        pattern: leadingSeparators + "mega" + phraseSeparator + "phone" + phraseBoundary,
         options: [.caseInsensitive]
     )
     private static let trailingSeparators = CharacterSet.whitespacesAndNewlines

--- a/Tests/AppContextServiceTests.swift
+++ b/Tests/AppContextServiceTests.swift
@@ -8,6 +8,8 @@ struct AppContextServiceTests {
         testNonStrippingModelPreservesExistingBehavior()
         testWakeCommandIncludesPreviousTextAndScreenContext()
         testWakeCommandResponseWrappersAreRemoved()
+        testAppWritingContextClassification()
+        testCleanupPromptUsesLocalAppStyle()
         TranscriptTidierTests.run()
         DictionaryStoreTests.run()
         WakePhraseMatcherTests.run()
@@ -60,6 +62,7 @@ struct AppContextServiceTests {
         let prompt = AppleFoundationModelsPostProcessor.commandPrompt(
             command: "make that formal",
             appName: "Mail",
+            bundleIdentifier: "com.apple.mail",
             windowTitle: "Draft — Project update",
             contextSummary: "The user is composing an email reply.",
             selectedText: "Earlier text selected in the draft.",
@@ -70,10 +73,55 @@ struct AppContextServiceTests {
         expect(prompt.contains("RECENT TEXT INSERTED BY THE USER:"), "Previous-text label missing")
         expect(prompt.contains("hey, can you send this over by friday?"), "Previous dictation missing")
         expect(prompt.contains("Destination app: Mail"), "Destination app context missing")
+        expect(prompt.contains("Writing context: email"), "Email writing context missing")
+        expect(prompt.contains("Do not invent a greeting, sign-off, subject, or details."), "Safe email guidance missing")
         expect(prompt.contains("Window: Draft — Project update"), "Window context missing")
         expect(prompt.contains("Context: The user is composing an email reply."), "Screen context missing")
         expect(prompt.contains("Current selected text: Earlier text selected in the draft."), "Selected screen text missing")
         expect(prompt.contains("make that formal"), "Spoken follow-up missing")
+    }
+
+    private static func testAppWritingContextClassification() {
+        expect(
+            AppWritingContext.classify(appName: "Mail", bundleIdentifier: "com.apple.mail", windowTitle: nil) == .email,
+            "Mail should use email writing context"
+        )
+        expect(
+            AppWritingContext.classify(appName: "Slack", bundleIdentifier: "com.tinyspeck.slackmacgap", windowTitle: nil) == .workChat,
+            "Slack should use work-chat writing context"
+        )
+        expect(
+            AppWritingContext.classify(appName: "Discord", bundleIdentifier: "com.hnc.Discord", windowTitle: nil) == .casualChat,
+            "Discord should use casual-chat writing context"
+        )
+        expect(
+            AppWritingContext.classify(appName: "Terminal", bundleIdentifier: "com.apple.Terminal", windowTitle: nil) == .codeOrTerminal,
+            "Terminal should preserve technical writing"
+        )
+        expect(
+            AppWritingContext.classify(appName: "Safari", bundleIdentifier: "com.apple.Safari", windowTitle: "Roadmap - Google Docs") == .document,
+            "Google Docs should use document writing context"
+        )
+    }
+
+    private static func testCleanupPromptUsesLocalAppStyle() {
+        let request = SmartCleanupRequest(
+            transcript: "uh hey can you send that by friday",
+            appName: "Slack",
+            bundleIdentifier: "com.tinyspeck.slackmacgap",
+            windowTitle: "Megaphone | project",
+            selectedText: nil,
+            contextSummary: "",
+            vocabulary: [],
+            corrections: [],
+            outputLanguage: "English",
+            customInstructions: ""
+        )
+        let prompt = AppleFoundationModelsPostProcessor.cleanupPrompt(for: request)
+
+        expect(prompt.contains("Writing context: work chat"), "Cleanup prompt lost Slack context")
+        expect(prompt.contains("concise, professional chat formatting"), "Slack cleanup guidance missing")
+        expect(prompt.contains("do not make the message more formal unless asked"), "Cleanup should preserve tone")
     }
 
     private static func testWakeCommandResponseWrappersAreRemoved() {

--- a/Tests/AppContextServiceTests.swift
+++ b/Tests/AppContextServiceTests.swift
@@ -7,6 +7,7 @@ struct AppContextServiceTests {
         testQwenReasoningOutputIsStripped()
         testNonStrippingModelPreservesExistingBehavior()
         testWakeCommandIncludesPreviousTextAndScreenContext()
+        testWakeCommandResponseWrappersAreRemoved()
         TranscriptTidierTests.run()
         DictionaryStoreTests.run()
         WakePhraseMatcherTests.run()
@@ -73,6 +74,26 @@ struct AppContextServiceTests {
         expect(prompt.contains("Context: The user is composing an email reply."), "Screen context missing")
         expect(prompt.contains("Current selected text: Earlier text selected in the draft."), "Selected screen text missing")
         expect(prompt.contains("make that formal"), "Spoken follow-up missing")
+    }
+
+    private static func testWakeCommandResponseWrappersAreRemoved() {
+        let cases = [
+            ("<response>Hello</response>", "Hello"),
+            ("  <RESPONSE >\nHello\n</Response >  ", "Hello"),
+            ("<response><response>Hello</response></response>", "Hello"),
+            ("<response>Hello", "Hello"),
+            ("Hello</response>", "Hello"),
+            ("Use <response> as the element name.", "Use <response> as the element name."),
+            ("ordinary text", "ordinary text"),
+            ("<response></response>", "")
+        ]
+
+        for (raw, expected) in cases {
+            expectEqual(
+                AppleFoundationModelsPostProcessor.normalizeCommandOutput(raw),
+                expected
+            )
+        }
     }
 
     private static func expectEqual(_ actual: String?, _ expected: String, file: StaticString = #file, line: UInt = #line) {

--- a/Tests/WakePhraseMatcherTests.swift
+++ b/Tests/WakePhraseMatcherTests.swift
@@ -5,6 +5,7 @@ enum WakePhraseMatcherTests {
         testHeyMegaphoneIsAlwaysRecognized()
         testPlainMegaphoneToggle()
         testCommonRecognitionAliases()
+        testHiddenRecognitionHints()
         testPhraseBoundariesAndPosition()
         testTrailingDictation()
         testPartialResultSuppression()
@@ -45,6 +46,9 @@ enum WakePhraseMatcherTests {
             "he made a phone, write this",
             "hay mega foam, write this",
             "hi mega form, write this",
+            "hey megafoam, write this",
+            "hey megaform, write this",
+            "hey megafone, write this",
             "hey mecca phone, write this",
             "hey mecha phone, write this",
             "hey megha phone, write this",
@@ -65,11 +69,10 @@ enum WakePhraseMatcherTests {
             )
         }
 
-        for transcript in ["mega phone, write this"] {
-            expectEqual(WakePhraseMatcher.detect(in: transcript), nil)
+        for transcript in ["mega phone, write this", "mega—phone, write this"] {
             expectEqual(
-                WakePhraseMatcher.detect(in: transcript, plainMegaphoneEnabled: true),
-                WakePhraseMatch(phrase: .megaphone, trailingText: "write this")
+                WakePhraseMatcher.detect(in: transcript),
+                WakePhraseMatch(phrase: .heyMegaphone, trailingText: "write this")
             )
         }
 
@@ -80,6 +83,17 @@ enum WakePhraseMatcherTests {
                 "Fuzzy alias escaped the Hey-only guard for \(transcript.debugDescription)"
             )
         }
+    }
+
+    private static func testHiddenRecognitionHints() {
+        expectEqual(WakePhraseMatcher.recognitionHints.contains("Hey Megaphone"), true, "Canonical wake hint missing")
+        expectEqual(WakePhraseMatcher.recognitionHints.contains("Hey Mega Phone"), true, "Segmented wake hint missing")
+        expectEqual(WakePhraseMatcher.recognitionHints.contains("Hey Make a Phone"), true, "Acoustic wake hint missing")
+        expectEqual(
+            WakePhraseMatcher.recognitionHints.allSatisfy { $0.lowercased().hasPrefix("hey") || $0 == "Megaphone" },
+            true,
+            "Unsafe plain acoustic alias leaked into recognition hints"
+        )
     }
 
     private static func testPhraseBoundariesAndPosition() {


### PR DESCRIPTION
## What changed

- strip leaked `<response>` wrappers from Hey Megaphone results, with prompt and output-level defenses
- recover `mega phone` when SpeechAnalyzer segments or drops the quiet leading “Hey”, and bias recognition with hidden Megaphone aliases
- restore local app-aware writing modes for Mail, Slack/Teams, Discord/Messages, documents, and code/terminal surfaces
- carry bundle ID, window title, selected text, and recent inserted text into the on-device Foundation Models prompts

App-aware formatting remains fully local. This does not re-enable screenshot capture or cloud context. Ordinary cleanup only adapts punctuation and paragraph formatting; it does not invent greetings, sign-offs, or details.

## Verification

- `make test` on macOS 26 / Apple silicon
- clean full `Megaphone Dev.app` build
- `codesign --verify --deep --strict`
