### PR TITLE
Close writing-context gaps for chat apps and webmail titles

### DIFF
--- a/Sources/AppleFoundationModelsPostProcessor.swift
+++ b/Sources/AppleFoundationModelsPostProcessor.swift
@@ -59,14 +59,23 @@ enum AppWritingContext: String, Equatable, Sendable {
         let title = windowTitle?.lowercased() ?? ""
         let identity = "\(app) \(bundle)"
         let all = "\(identity) \(title)"
+        // An email address in a window title ("kuber@gmail.com - Google
+        // Account") must not read as webmail; only the service name counts.
+        let allWithoutAddresses = all.replacingOccurrences(
+            of: #"[a-z0-9._%+-]+@[a-z0-9.-]+"#,
+            with: " ",
+            options: .regularExpression
+        )
 
         if all.contains("slack") || all.contains("msteams") || all.contains("microsoft teams") {
             return .workChat
         }
-        if all.contains("discord") || bundle.contains("com.apple.mobilesms") || app == "messages" {
+        if all.contains("discord") || all.contains("whatsapp") || all.contains("telegram")
+            || bundle.contains("com.apple.mobilesms") || app == "messages" {
             return .casualChat
         }
-        if bundle.contains("com.apple.mail") || app == "mail" || all.contains("outlook") || all.contains("gmail") {
+        if bundle.contains("com.apple.mail") || app == "mail"
+            || allWithoutAddresses.contains("outlook") || allWithoutAddresses.contains("gmail") {
             return .email
         }
         let codeApps = [

--- a/Tests/AppContextServiceTests.swift
+++ b/Tests/AppContextServiceTests.swift
@@ -113,6 +113,22 @@ struct AppContextServiceTests {
             AppWritingContext.classify(appName: "Safari", bundleIdentifier: "com.apple.Safari", windowTitle: "Discord | #general") == .casualChat,
             "Discord in a browser should use casual-chat writing context"
         )
+        expect(
+            AppWritingContext.classify(appName: "WhatsApp", bundleIdentifier: "net.whatsapp.WhatsApp", windowTitle: nil) == .casualChat,
+            "WhatsApp should use casual-chat writing context"
+        )
+        expect(
+            AppWritingContext.classify(appName: "Telegram", bundleIdentifier: "ru.keepcoder.Telegram", windowTitle: nil) == .casualChat,
+            "Telegram should use casual-chat writing context"
+        )
+        expect(
+            AppWritingContext.classify(appName: "Google Chrome", bundleIdentifier: "com.google.Chrome", windowTitle: "Inbox (42) - kuber@gmail.com - Gmail") == .email,
+            "Gmail in a browser should use email writing context"
+        )
+        expect(
+            AppWritingContext.classify(appName: "Google Chrome", bundleIdentifier: "com.google.Chrome", windowTitle: "kuber@gmail.com - Google Account") == .neutral,
+            "A Gmail address alone should not read as email writing context"
+        )
     }
 
     private static func testCleanupPromptUsesLocalAppStyle() {


### PR DESCRIPTION
Fixes two gaps found while auditing the app-awareness classifier (`AppWritingContext.classify`):

1. **WhatsApp and Telegram now classify as casual chat.** They previously fell through to "general writing" because only Messages and Discord were in the casual-chat list. Matching runs on app name, bundle ID, and window title, so WhatsApp Web / Telegram Web in a browser tab are covered too.

2. **Email addresses in window titles no longer trigger the email context.** The Gmail/Outlook check was a bare substring match, so any title containing a `@gmail.com` address (e.g. "kuber@gmail.com - Google Account" in Chrome) classified as email. Addresses are now stripped before matching; real webmail titles like "Inbox (42) - kuber@gmail.com - Gmail" still match on the standalone service name.

Added four classification tests covering both fixes. Verified with `make test` on macOS 26.5 (arm64): all tests pass.