### PR TITLE
Dictionary starring and usage-based ranking

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -2698,6 +2698,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
                             default:
                                 break
                             }
+                            if !trimmedFinalTranscript.isEmpty {
+                                DictionaryStore.shared.recordUsage(in: trimmedFinalTranscript)
+                            }
                         }
                         self.recordPipelineHistoryEntry(
                             rawTranscript: trimmedRawTranscript,

--- a/Sources/DictionaryStore.swift
+++ b/Sources/DictionaryStore.swift
@@ -19,6 +19,8 @@ struct DictionaryEntry: Codable, Identifiable, Equatable {
     var status: Status
     var isEnabled: Bool
     var observationCount: Int
+    var starred: Bool
+    var usageCount: Int
     var createdAt: Date
     var updatedAt: Date
 
@@ -29,6 +31,8 @@ struct DictionaryEntry: Codable, Identifiable, Equatable {
         status: Status,
         isEnabled: Bool = true,
         observationCount: Int = 0,
+        starred: Bool = false,
+        usageCount: Int = 0,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) {
@@ -38,8 +42,35 @@ struct DictionaryEntry: Codable, Identifiable, Equatable {
         self.status = status
         self.isEnabled = isEnabled
         self.observationCount = observationCount
+        self.starred = starred
+        self.usageCount = usageCount
         self.createdAt = createdAt
         self.updatedAt = updatedAt
+    }
+
+    /// Entries stored before starring/usage ranking shipped lack these keys;
+    /// decode them with safe defaults so existing dictionaries keep loading.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        term = try container.decode(String.self, forKey: .term)
+        source = try container.decode(Source.self, forKey: .source)
+        status = try container.decode(Status.self, forKey: .status)
+        isEnabled = try container.decode(Bool.self, forKey: .isEnabled)
+        observationCount = try container.decode(Int.self, forKey: .observationCount)
+        starred = try container.decodeIfPresent(Bool.self, forKey: .starred) ?? false
+        usageCount = try container.decodeIfPresent(Int.self, forKey: .usageCount) ?? 0
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+    }
+
+    /// Prompt-facing ranking: starred terms first, then most-used, then
+    /// alphabetical — so downstream caps (e.g. `prefix(40)`) keep the terms
+    /// the user actually relies on.
+    static func promptRanking(_ lhs: DictionaryEntry, _ rhs: DictionaryEntry) -> Bool {
+        if lhs.starred != rhs.starred { return lhs.starred }
+        if lhs.usageCount != rhs.usageCount { return lhs.usageCount > rhs.usageCount }
+        return lhs.term.localizedCaseInsensitiveCompare(rhs.term) == .orderedAscending
     }
 }
 
@@ -96,8 +127,8 @@ final class DictionaryStore: ObservableObject {
     var activeTerms: [String] {
         entries
             .filter { $0.status == .active && $0.isEnabled }
+            .sorted(by: DictionaryEntry.promptRanking)
             .map(\.term)
-            .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
     }
 
     /// Projection consumed by the existing newline-delimited vocabulary pipeline.
@@ -145,6 +176,54 @@ final class DictionaryStore: ObservableObject {
         entries[index].isEnabled = enabled
         entries[index].updatedAt = Date()
         persist()
+    }
+
+    func setStarred(_ starred: Bool, for id: UUID) {
+        guard let index = entries.firstIndex(where: { $0.id == id }) else { return }
+        entries[index].starred = starred
+        entries[index].updatedAt = Date()
+        persist()
+    }
+
+    /// Counts which enabled entries a finished dictation actually used, so the
+    /// vocabulary ranking favors terms that keep showing up. Called once per
+    /// successful dictation with the final pasted transcript; scans enabled
+    /// active entries in a single pass and persists at most once.
+    func recordUsage(in transcript: String) {
+        let transcript = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !transcript.isEmpty else { return }
+        var didIncrement = false
+        for index in entries.indices where entries[index].status == .active && entries[index].isEnabled {
+            guard Self.containsWholeWord(entries[index].term, in: transcript) else { continue }
+            entries[index].usageCount += 1
+            didIncrement = true
+        }
+        if didIncrement { persist() }
+    }
+
+    /// Case- and diacritic-insensitive containment that only matches at word
+    /// boundaries, so "AI" never matches inside "maintain".
+    static func containsWholeWord(_ term: String, in text: String) -> Bool {
+        guard !term.isEmpty else { return false }
+        var searchStart = text.startIndex
+        while searchStart < text.endIndex,
+              let found = text.range(
+                  of: term,
+                  options: [.caseInsensitive, .diacriticInsensitive],
+                  range: searchStart..<text.endIndex
+              ) {
+            let boundedBefore = found.lowerBound == text.startIndex
+                || !isWordCharacter(text[text.index(before: found.lowerBound)])
+            let boundedAfter = found.upperBound == text.endIndex
+                || !isWordCharacter(text[found.upperBound])
+            if boundedBefore && boundedAfter { return true }
+            searchStart = text.index(after: found.lowerBound)
+        }
+        return false
+    }
+
+    private static func isWordCharacter(_ character: Character) -> Bool {
+        character.isLetter || character.isNumber
     }
 
     func acceptSuggestion(id: UUID) {

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -1210,7 +1210,8 @@ struct DictionarySettingsView: View {
     }
 
     private var savedEntries: [DictionaryEntry] {
-        store.entries.filter { $0.status == .active && matchesSearch($0) }
+        let matches = store.entries.filter { $0.status == .active && matchesSearch($0) }
+        return matches.filter(\.starred) + matches.filter { !$0.starred }
     }
 
     var body: some View {
@@ -1331,6 +1332,10 @@ struct DictionarySettingsView: View {
                         Text("·")
                         Text("Heard \(entry.observationCount) times")
                     }
+                    if !isSuggestion && entry.usageCount > 0 {
+                        Text("·")
+                        Text("Used \(entry.usageCount) time\(entry.usageCount == 1 ? "" : "s")")
+                    }
                 }
                 .font(.caption2)
                 .foregroundStyle(.secondary)
@@ -1343,6 +1348,12 @@ struct DictionarySettingsView: View {
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
             } else {
+                Button { store.setStarred(!entry.starred, for: entry.id) } label: {
+                    Image(systemName: entry.starred ? "star.fill" : "star")
+                        .foregroundStyle(entry.starred ? Color.yellow : Color.secondary)
+                }
+                .buttonStyle(.borderless)
+                .help(entry.starred ? "Unstar this word" : "Star this word so it is always prioritized")
                 Toggle("", isOn: Binding(
                     get: { entry.isEnabled },
                     set: { store.setEnabled($0, for: entry.id) }

--- a/Tests/DictionaryStoreTests.swift
+++ b/Tests/DictionaryStoreTests.swift
@@ -10,6 +10,11 @@ enum DictionaryStoreTests {
         testPersistence()
         testConservativeCandidateExtraction()
         testDismissedSuggestionStaysDismissed()
+        testDecodesEntriesStoredBeforeRanking()
+        testPromptRankingOrder()
+        testUsageMatchingRespectsWordBoundaries()
+        testUsageIncrementsOnlyEnabledEntries()
+        testStarAndUsagePersist()
     }
 
     private static func testManualTermsAndProjection() {
@@ -124,6 +129,89 @@ enum DictionaryStoreTests {
         let restored = try! store.addManual("Kuber")
         expectEqual(restored.status, .active)
         expectEqual(restored.source, .manual)
+    }
+
+    private static func testDecodesEntriesStoredBeforeRanking() {
+        let suite = "DictionaryStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        // A stored blob from before `starred`/`usageCount` existed.
+        let legacyBlob = """
+        [{"id":"1B8F4E2A-6C1D-4E5B-9A3F-2D7C8E0B4A61","term":"Megaphone","source":"manual",\
+        "status":"active","isEnabled":true,"observationCount":0,"createdAt":776000000,"updatedAt":776000000}]
+        """
+        defaults.set(Data(legacyBlob.utf8), forKey: "entries")
+        defaults.set(true, forKey: "migrated")
+        let store = DictionaryStore(
+            defaults: defaults,
+            storageKey: "entries",
+            migrationKey: "migrated",
+            legacyVocabularyKey: "legacy"
+        )
+        expectEqual(store.entries.count, 1)
+        expectEqual(store.entries.first?.term, "Megaphone")
+        expectEqual(store.entries.first?.starred, false)
+        expectEqual(store.entries.first?.usageCount, 0)
+        expectEqual(store.activeTerms, ["Megaphone"])
+        defaults.removePersistentDomain(forName: suite)
+    }
+
+    private static func testPromptRankingOrder() {
+        let (store, defaults) = makeStore()
+        defer { clear(defaults) }
+
+        _ = try! store.addManual("Obsidian")
+        _ = try! store.addManual("Kuber")
+        let starredEntry = try! store.addManual("Zig")
+        _ = try! store.addManual("Apple")
+        store.setStarred(true, for: starredEntry.id)
+        store.recordUsage(in: "Ship the Kuber build")
+        store.recordUsage(in: "Ping Kuber about Obsidian")
+
+        // Starred beats usage, usage beats alphabetical, alphabetical breaks ties.
+        expectEqual(store.activeTerms, ["Zig", "Kuber", "Obsidian", "Apple"])
+    }
+
+    private static func testUsageMatchingRespectsWordBoundaries() {
+        let (store, defaults) = makeStore()
+        defer { clear(defaults) }
+
+        _ = try! store.addManual("AI")
+        store.recordUsage(in: "We maintain the daily chain")
+        expectEqual(store.entries.first?.usageCount, 0)
+        store.recordUsage(in: "The AI pipeline, obviously.")
+        expectEqual(store.entries.first?.usageCount, 1)
+        // Punctuation is a boundary; repeats within one dictation count once.
+        store.recordUsage(in: "ai, ai everywhere")
+        expectEqual(store.entries.first?.usageCount, 2)
+        expect(DictionaryStore.containsWholeWord("Foundation Models", in: "use Foundation Models."), "Missed a multi-word phrase")
+        expect(!DictionaryStore.containsWholeWord("Foundation Models", in: "foundation modelscope"), "Matched inside a longer word")
+    }
+
+    private static func testUsageIncrementsOnlyEnabledEntries() {
+        let (store, defaults) = makeStore()
+        defer { clear(defaults) }
+
+        _ = try! store.addManual("SpeechAnalyzer")
+        let disabled = try! store.addManual("Obsidian")
+        store.setEnabled(false, for: disabled.id)
+        store.observe(candidateTerms: ["Claurst"]) // suggested, not active
+        store.recordUsage(in: "SpeechAnalyzer feeds Obsidian and Claurst")
+        expectEqual(store.entries.first { $0.term == "SpeechAnalyzer" }?.usageCount, 1)
+        expectEqual(store.entries.first { $0.term == "Obsidian" }?.usageCount, 0)
+        expectEqual(store.entries.first { $0.term == "Claurst" }?.usageCount, 0)
+    }
+
+    private static func testStarAndUsagePersist() {
+        let suite = "DictionaryStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        let store = DictionaryStore(defaults: defaults, storageKey: "entries", migrationKey: "migrated")
+        let entry = try! store.addManual("Megaphone")
+        store.setStarred(true, for: entry.id)
+        store.recordUsage(in: "Megaphone shipped")
+        let reloaded = DictionaryStore(defaults: defaults, storageKey: "entries", migrationKey: "migrated")
+        expectEqual(reloaded.entries.first?.starred, true)
+        expectEqual(reloaded.entries.first?.usageCount, 1)
+        defaults.removePersistentDomain(forName: suite)
     }
 
     private static func makeStore() -> (DictionaryStore, UserDefaults) {


### PR DESCRIPTION
Star pinning and per-term usage counts so the prompt vocabulary cap (`prefix(40)`) keeps the terms you actually use.

- `DictionaryEntry` gains `starred`/`usageCount` with backward-compatible decoding (migration test decodes a pre-feature JSON blob).
- `recordUsage(in:)` hooks the dictation-commit point: single pass over enabled entries, word-boundary + diacritic-insensitive matching ("AI" never matches inside "maintain"), one persist per dictation, `updatedAt` deliberately untouched so pruning is unaffected.
- Ranking (starred → usage → alphabetical) applies to every prompt vocabulary path including transcription biasing; Settings shows a star toggle and "Used N times", starred entries grouped first.

Verified on macOS 26.5 (arm64): `make test` passes (5 new tests), full build clean.
---
*All eight feature PRs register tests in `Tests/AppContextServiceTests.swift` and some extend the Makefile test list, so each merge after the first needs a trivial conflict resolution there. Suggested merge order: dictionary-ranking → formality-dial → caret-context → transforms → scratch-that → raw-undo → rebindable-cancel → mouse-ptt.*
