### PR TITLE
Per-app writing formality dial

### DIFF
--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -251,6 +251,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let commandModeStyleStorageKey = "command_mode_style"
     private let commandModeManualModifierStorageKey = "command_mode_manual_modifier"
     private let outputLanguageStorageKey = "output_language"
+    private let writingFormalityByContextStorageKey = "writing_formality_by_context"
     private let dictationAudioInterruptionEnabledStorageKey = "dictation_audio_interruption_enabled"
     private let pasteAfterShortcutReleaseDelay: TimeInterval = 0.03
     private let pressEnterAfterPasteDelay: TimeInterval = 0.08
@@ -421,6 +422,25 @@ final class AppState: ObservableObject, @unchecked Sendable {
         didSet {
             UserDefaults.standard.set(outputLanguage, forKey: outputLanguageStorageKey)
         }
+    }
+
+    /// Writing-style dial per writing-context bucket, keyed by
+    /// `AppWritingContext.rawValue` with `WritingFormality.rawValue` values.
+    /// Missing entries mean `.balanced` (the current behavior). Code and
+    /// terminal apps are exempt and never consult this.
+    @Published var writingFormalityByContext: [String: String] {
+        didSet {
+            UserDefaults.standard.set(writingFormalityByContext, forKey: writingFormalityByContextStorageKey)
+        }
+    }
+
+    func writingFormality(for context: AppWritingContext) -> WritingFormality {
+        guard context != .codeOrTerminal else { return .balanced }
+        return WritingFormality(rawValue: writingFormalityByContext[context.rawValue] ?? "") ?? .balanced
+    }
+
+    func setWritingFormality(_ formality: WritingFormality, for context: AppWritingContext) {
+        writingFormalityByContext[context.rawValue] = formality.rawValue
     }
 
     @Published var shortcutStartDelay: TimeInterval {
@@ -634,6 +654,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let customSystemPromptLastModified = UserDefaults.standard.string(forKey: customSystemPromptLastModifiedStorageKey) ?? ""
         let customContextPromptLastModified = UserDefaults.standard.string(forKey: customContextPromptLastModifiedStorageKey) ?? ""
         let outputLanguage = UserDefaults.standard.string(forKey: outputLanguageStorageKey) ?? ""
+        let writingFormalityByContext = UserDefaults.standard
+            .dictionary(forKey: writingFormalityByContextStorageKey) as? [String: String] ?? [:]
         let shortcutStartDelay = max(0, UserDefaults.standard.double(forKey: shortcutStartDelayStorageKey))
         let isCommandModeEnabled = UserDefaults.standard.object(forKey: commandModeEnabledStorageKey) == nil
             ? false
@@ -719,6 +741,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.customSystemPromptLastModified = customSystemPromptLastModified
         self.customContextPromptLastModified = customContextPromptLastModified
         self.outputLanguage = outputLanguage
+        self.writingFormalityByContext = writingFormalityByContext
         self.shortcutStartDelay = shortcutStartDelay
         self.preserveClipboard = preserveClipboard
         self.preserveExactWording = smartCleanupMode == .exact
@@ -2395,6 +2418,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
         let corrections = TranscriptTidier.CorrectionMapping.parse(wordCorrections)
+        // The user's standing writing-style dial for wherever this dictation
+        // lands, resolved from the context captured at recording time.
+        let formality = writingFormality(for: AppWritingContext.classify(
+            appName: context.appName,
+            bundleIdentifier: context.bundleIdentifier,
+            windowTitle: context.windowTitle
+        ))
 
         if wakeCommandsEnabled, case .dictation = intent, let wake = WakePhraseMatcher.detect(
             in: trimmedRawTranscript,
@@ -2423,6 +2453,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     previousText: previousText,
                     screenText: screenText,
                     vocabulary: vocabulary,
+                    formality: formality,
                     timeout: 5
                 )
                 return (
@@ -2451,6 +2482,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                     bundleIdentifier: context.bundleIdentifier,
                     windowTitle: context.windowTitle,
                     vocabulary: vocabulary,
+                    formality: formality,
                     sessionID: smartSessionID,
                     timeout: 4
                 )
@@ -2491,7 +2523,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 outputLanguage: outputLanguage,
                 customInstructions: [customSystemPrompt, customContextPrompt]
                     .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
-                    .joined(separator: "\n")
+                    .joined(separator: "\n"),
+                formality: formality
             )
             let result = try await AppleFoundationModelsPostProcessor.shared.cleanup(
                 request,

--- a/Sources/AppleFoundationModelsPostProcessor.swift
+++ b/Sources/AppleFoundationModelsPostProcessor.swift
@@ -39,6 +39,37 @@ struct SmartCleanupRequest: Sendable {
     let corrections: [Correction]
     let outputLanguage: String
     let customInstructions: String
+    var formality: WritingFormality = .balanced
+}
+
+/// The user's standing preference for how their words are polished in a given
+/// writing context. This is a register/punctuation dial for cleanup, never a
+/// rewrite instruction: meaning, ideas, and hedges always stay the speaker's.
+enum WritingFormality: String, Codable, CaseIterable, Sendable {
+    case casual
+    case balanced
+    case formal
+
+    /// One short sentence appended to the cleanup guidance. `balanced` is the
+    /// current behavior and adds nothing.
+    var guidanceSentence: String? {
+        switch self {
+        case .balanced:
+            return nil
+        case .casual:
+            return "The speaker prefers a relaxed register: contractions are welcome and punctuation stays light."
+        case .formal:
+            return "The speaker prefers a polished register: full sentences, professional punctuation, and spoken shorthand written out — “gonna” becomes “going to”, “wanna” becomes “want to”."
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .casual: return "Casual"
+        case .balanced: return "Balanced"
+        case .formal: return "Formal"
+        }
+    }
 }
 
 enum AppWritingContext: String, Equatable, Sendable {
@@ -121,7 +152,7 @@ enum AppWritingContext: String, Equatable, Sendable {
         }
     }
 
-    func cleanupGuidance(markdown: Bool) -> String {
+    func cleanupGuidance(markdown: Bool, formality: WritingFormality = .balanced) -> String {
         let base: String
         switch self {
         case .email:
@@ -137,12 +168,19 @@ enum AppWritingContext: String, Equatable, Sendable {
         case .neutral:
             base = "Use neutral, readable punctuation and preserve the speaker's tone."
         }
-        guard markdown else { return base }
-        return base + " Markdown renders here: use markdown lists, emphasis, and headers when the dictation clearly calls for them."
+        var guidance = base
+        if markdown {
+            guidance += " Markdown renders here: use markdown lists, emphasis, and headers when the dictation clearly calls for them."
+        }
+        // Technical surfaces are exempt: the dial never touches code or commands.
+        if self != .codeOrTerminal, let preference = formality.guidanceSentence {
+            guidance += " " + preference
+        }
+        return guidance
     }
 
-    func commandGuidance(markdown: Bool) -> String {
-        "When the request does not specify a style, shape the result for \(label). \(cleanupGuidance(markdown: markdown)) An explicit style request always wins."
+    func commandGuidance(markdown: Bool, formality: WritingFormality = .balanced) -> String {
+        "When the request does not specify a style, shape the result for \(label). \(cleanupGuidance(markdown: markdown, formality: formality)) An explicit style request always wins."
     }
 }
 
@@ -256,6 +294,7 @@ actor AppleFoundationModelsPostProcessor {
         bundleIdentifier: String?,
         windowTitle: String?,
         vocabulary: [String],
+        formality: WritingFormality = .balanced,
         sessionID: UUID?,
         timeout: TimeInterval
     ) async throws -> SmartCleanupResponse {
@@ -274,7 +313,8 @@ actor AppleFoundationModelsPostProcessor {
             appName: appName,
             bundleIdentifier: bundleIdentifier,
             windowTitle: windowTitle,
-            vocabulary: vocabulary
+            vocabulary: vocabulary,
+            formality: formality
         )
         let started = ContinuousClock.now
         let output = Self.normalizeCommandOutput(
@@ -294,7 +334,8 @@ actor AppleFoundationModelsPostProcessor {
         appName: String?,
         bundleIdentifier: String?,
         windowTitle: String?,
-        vocabulary: [String]
+        vocabulary: [String],
+        formality: WritingFormality = .balanced
     ) -> String {
         let vocabularyHint = vocabulary.isEmpty
             ? ""
@@ -313,7 +354,7 @@ actor AppleFoundationModelsPostProcessor {
         )
         return """
         \(appHint)\(windowHint)Writing context: \(writingContext.label)
-        App-aware guidance: Apply this only when the spoken editing command does not specify another style. \(writingContext.cleanupGuidance(markdown: markdown))
+        App-aware guidance: Apply this only when the spoken editing command does not specify another style. \(writingContext.cleanupGuidance(markdown: markdown, formality: formality))
         \(vocabularyHint)SELECTED TEXT:
         <selected_text>
         \(selectedText)
@@ -336,6 +377,7 @@ actor AppleFoundationModelsPostProcessor {
         previousText: String?,
         screenText: String? = nil,
         vocabulary: [String],
+        formality: WritingFormality = .balanced,
         timeout: TimeInterval
     ) async throws -> WakeCommandResponse {
         guard case .available = availability() else {
@@ -357,7 +399,8 @@ actor AppleFoundationModelsPostProcessor {
             selectedText: selectedText,
             previousText: previousText,
             screenText: screenText,
-            vocabulary: vocabulary
+            vocabulary: vocabulary,
+            formality: formality
         )
         let started = ContinuousClock.now
         let rawOutput = Self.normalizeCommandOutput(
@@ -405,7 +448,8 @@ actor AppleFoundationModelsPostProcessor {
         selectedText: String?,
         previousText: String?,
         screenText: String? = nil,
-        vocabulary: [String]
+        vocabulary: [String],
+        formality: WritingFormality = .balanced
     ) -> String {
         let vocabularyHint = vocabulary.isEmpty
             ? ""
@@ -424,7 +468,7 @@ actor AppleFoundationModelsPostProcessor {
         )
         let writingHint = """
         Writing context: \(writingContext.label)
-        App-aware guidance: \(writingContext.commandGuidance(markdown: markdown))
+        App-aware guidance: \(writingContext.commandGuidance(markdown: markdown, formality: formality))
         """
         let contextHint = contextSummary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             ? ""
@@ -570,7 +614,7 @@ actor AppleFoundationModelsPostProcessor {
             windowTitle: request.windowTitle
         )
         hints.append("Writing context: \(writingContext.label)")
-        hints.append("App-aware cleanup: \(writingContext.cleanupGuidance(markdown: markdown))")
+        hints.append("App-aware cleanup: \(writingContext.cleanupGuidance(markdown: markdown, formality: request.formality))")
         if let selected = request.selectedText?.trimmingCharacters(in: .whitespacesAndNewlines), !selected.isEmpty {
             hints.append("Nearby selected text (spelling/tone hint only): \(selected.prefix(300))")
         }

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -442,6 +442,9 @@ struct GeneralSettingsView: View {
                 SettingsCard("Cleanup", icon: "sparkles") {
                     cleanupSection
                 }
+                SettingsCard("Writing Style", icon: "textformat") {
+                    writingStyleSection
+                }
                 SettingsCard("Output Language", icon: "globe") {
                     outputLanguageSection
                 }
@@ -749,6 +752,41 @@ struct GeneralSettingsView: View {
             return "Instant deterministic cleanup for fillers, stutters, repeated words, and spacing."
         case .exact:
             return "Preserves the words you spoke, with only the minimum formatting needed for insertion."
+        }
+    }
+
+    // MARK: Writing Style
+
+    private var writingStyleSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            formalityRow("Email", context: .email)
+            formalityRow("Work chat", context: .workChat)
+            formalityRow("Personal chat", context: .casualChat)
+            formalityRow("Documents", context: .document)
+            formalityRow("Everything else", context: .neutral)
+
+            Text("How Smart Cleanup punctuates and polishes your words in each kind of app. Your wording and meaning are never changed; code and terminal apps always stay technical.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func formalityRow(_ label: String, context: AppWritingContext) -> some View {
+        HStack(spacing: 8) {
+            Text(label)
+                .font(.caption)
+            Spacer()
+            Picker("", selection: Binding(
+                get: { appState.writingFormality(for: context) },
+                set: { appState.setWritingFormality($0, for: context) }
+            )) {
+                ForEach(WritingFormality.allCases, id: \.self) { formality in
+                    Text(formality.title).tag(formality)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .frame(width: 260)
         }
     }
 

--- a/Tests/AppContextServiceTests.swift
+++ b/Tests/AppContextServiceTests.swift
@@ -12,6 +12,9 @@ struct AppContextServiceTests {
         testMarkdownSurfaceDetection()
         testCleanupPromptUsesLocalAppStyle()
         testSelectionPromptUsesDestinationContext()
+        testWritingFormalityGuidance()
+        testWritingFormalityPromptPlumbing()
+        testWritingFormalityStorageRoundTrip()
         TranscriptTidierTests.run()
         DictionaryStoreTests.run()
         WakePhraseMatcherTests.run()
@@ -225,6 +228,128 @@ struct AppContextServiceTests {
         expect(prompt.contains("Window: Draft — Launch"), "Edit prompt lost window context")
         expect(prompt.contains("Writing context: email"), "Edit prompt lost email style")
         expect(prompt.contains("Do not invent a greeting, sign-off, subject, or details."), "Edit prompt lost email safety")
+    }
+
+    private static let casualSentence = "The speaker prefers a relaxed register: contractions are welcome and punctuation stays light."
+    private static let formalSentence = "The speaker prefers a polished register: full sentences, professional punctuation, and spoken shorthand written out — “gonna” becomes “going to”, “wanna” becomes “want to”."
+
+    private static func testWritingFormalityGuidance() {
+        let dialContexts: [AppWritingContext] = [.email, .workChat, .casualChat, .document, .neutral]
+        for context in dialContexts {
+            expectEqual(
+                context.cleanupGuidance(markdown: false, formality: .balanced),
+                context.cleanupGuidance(markdown: false)
+            )
+            expect(
+                !context.cleanupGuidance(markdown: false).contains("register"),
+                "Balanced must add nothing for \(context)"
+            )
+            expect(
+                context.cleanupGuidance(markdown: false, formality: .casual).hasSuffix(casualSentence),
+                "Casual preference missing for \(context)"
+            )
+            expect(
+                context.cleanupGuidance(markdown: false, formality: .formal).hasSuffix(formalSentence),
+                "Formal preference missing for \(context)"
+            )
+            expect(
+                context.commandGuidance(markdown: false, formality: .formal).contains(formalSentence),
+                "Command guidance lost formal preference for \(context)"
+            )
+        }
+
+        // Markdown guidance and the formality preference must coexist.
+        let markdownFormal = AppWritingContext.document.cleanupGuidance(markdown: true, formality: .formal)
+        expect(markdownFormal.contains("Markdown renders here"), "Markdown guidance lost with formality set")
+        expect(markdownFormal.hasSuffix(formalSentence), "Formal preference lost on markdown surface")
+
+        // Code and terminal are always technical, whatever the dial says.
+        for formality in WritingFormality.allCases {
+            expectEqual(
+                AppWritingContext.codeOrTerminal.cleanupGuidance(markdown: false, formality: formality),
+                AppWritingContext.codeOrTerminal.cleanupGuidance(markdown: false)
+            )
+        }
+    }
+
+    private static func testWritingFormalityPromptPlumbing() {
+        func request(_ formality: WritingFormality) -> SmartCleanupRequest {
+            SmartCleanupRequest(
+                transcript: "hey uh can you send me the report by friday thanks",
+                appName: "Mail",
+                bundleIdentifier: "com.apple.mail",
+                windowTitle: "Draft",
+                selectedText: nil,
+                contextSummary: "",
+                vocabulary: [],
+                corrections: [],
+                outputLanguage: "",
+                customInstructions: "",
+                formality: formality
+            )
+        }
+        expect(
+            AppleFoundationModelsPostProcessor.cleanupPrompt(for: request(.formal)).contains(formalSentence),
+            "Cleanup prompt lost the formal dial"
+        )
+        expect(
+            AppleFoundationModelsPostProcessor.cleanupPrompt(for: request(.casual)).contains(casualSentence),
+            "Cleanup prompt lost the casual dial"
+        )
+        let balancedPrompt = AppleFoundationModelsPostProcessor.cleanupPrompt(for: request(.balanced))
+        expect(
+            !balancedPrompt.contains(formalSentence) && !balancedPrompt.contains(casualSentence),
+            "Balanced cleanup prompt must match current behavior"
+        )
+
+        let commandPrompt = AppleFoundationModelsPostProcessor.commandPrompt(
+            command: "reply saying thanks",
+            appName: "Slack",
+            bundleIdentifier: "com.tinyspeck.slackmacgap",
+            windowTitle: "Megaphone | project",
+            contextSummary: "",
+            selectedText: nil,
+            previousText: nil,
+            vocabulary: [],
+            formality: .formal
+        )
+        expect(commandPrompt.contains(formalSentence), "Command prompt lost the formal dial")
+
+        let selectionPrompt = AppleFoundationModelsPostProcessor.selectionPrompt(
+            selectedText: "can we ship this tomorrow",
+            command: "fix the punctuation",
+            appName: "Discord",
+            bundleIdentifier: "com.hnc.Discord",
+            windowTitle: nil,
+            vocabulary: [],
+            formality: .casual
+        )
+        expect(selectionPrompt.contains(casualSentence), "Selection prompt lost the casual dial")
+    }
+
+    private static func testWritingFormalityStorageRoundTrip() {
+        for formality in WritingFormality.allCases {
+            expect(
+                WritingFormality(rawValue: formality.rawValue) == formality,
+                "Raw-value round trip failed for \(formality)"
+            )
+        }
+        // Unknown or missing stored values fall back to balanced, the way
+        // AppState resolves the per-context dictionary.
+        expect(
+            WritingFormality(rawValue: "loud") == nil,
+            "Unknown stored value must be rejected so the caller defaults to balanced"
+        )
+        let stored = ["email": "formal", "casualChat": "casual"]
+        let decoded = AppWritingContext.email.rawValue
+        expect(
+            WritingFormality(rawValue: stored[decoded] ?? "") == .formal,
+            "Stored dictionary lookup by context raw value failed"
+        )
+        expect(
+            WritingFormality(rawValue: stored[AppWritingContext.neutral.rawValue] ?? "") == nil,
+            "Missing context entry must resolve to no explicit formality"
+        )
     }
 
     private static func testWakeCommandResponseWrappersAreRemoved() {


### PR DESCRIPTION
Wispr Flow's "Personalized Style," done locally: a Casual / Balanced / Formal dial per writing context (Email, Work chat, Personal chat, Documents, Everything else). Code/terminal is hard-exempt.

- Balanced (default) adds nothing — prompts are byte-identical to today.
- Casual/formal append ONE register-preference sentence to the app-aware guidance; phrased as the user's standing polish preference, never a rewrite instruction. Formal needed concrete examples to land on the small model ("gonna" → "going to").
- Plumbed through cleanup, wake-command, and edit-mode prompts; stored as `writing_formality_by_context`.

Live-validated on-device (real `cleanup()` runs): formal breaks sentences and expands shorthand without inventing content; casual keeps "gonna" and light punctuation; balanced identical to current behavior; meaning and hedges preserved in every case.

Verified on macOS 26.5 (arm64): `make test` passes, full build clean.
---
*All eight feature PRs register tests in `Tests/AppContextServiceTests.swift` and some extend the Makefile test list, so each merge after the first needs a trivial conflict resolution there. Suggested merge order: dictionary-ranking → formality-dial → caret-context → transforms → scratch-that → raw-undo → rebindable-cancel → mouse-ptt.*
