### PR TITLE
Match surrounding text when dictating at the caret

### DIFF
--- a/Sources/AppContextService.swift
+++ b/Sources/AppContextService.swift
@@ -14,6 +14,7 @@ struct AppContext {
     let bundleIdentifier: String?
     let windowTitle: String?
     let selectedText: String?
+    let textBeforeCaret: String?
     let currentActivity: String
 
     var contextSummary: String {
@@ -26,6 +27,11 @@ struct AppContext {
 /// the accessibility APIs. Megaphone is local-only; nothing here talks to a
 /// network.
 final class AppContextService {
+    /// How much text before the caret is captured as continuation context.
+    /// Enough to see the current sentence and the previous one; small enough
+    /// to stay cheap in the on-device model's prompt.
+    static let textBeforeCaretLimit = 240
+
     func collectSelectionSnapshot() -> AppSelectionSnapshot {
         guard let frontmostApp = NSWorkspace.shared.frontmostApplication else {
             return AppSelectionSnapshot(
@@ -100,6 +106,7 @@ final class AppContextService {
                 bundleIdentifier: nil,
                 windowTitle: nil,
                 selectedText: nil,
+                textBeforeCaret: nil,
                 currentActivity: "You are dictating in an unrecognized context."
             )
         }
@@ -115,6 +122,7 @@ final class AppContextService {
             bundleIdentifier: bundleIdentifier,
             windowTitle: windowTitle,
             selectedText: selectedText,
+            textBeforeCaret: textBeforeCaret(from: appElement),
             currentActivity: Self.localActivity(
                 appName: appName,
                 bundleIdentifier: bundleIdentifier,
@@ -140,6 +148,49 @@ final class AppContextService {
             ? " Nearby selected text is available as a tone and spelling hint."
             : ""
         return "The user is writing in \(activeApp), treated as \(writingContext.label).\(selectionHint)"
+    }
+
+    /// Captures up to `textBeforeCaretLimit` characters immediately before the
+    /// caret in the focused editable element, so smart cleanup can continue
+    /// existing text with matching capitalization and punctuation. Returns nil
+    /// when there is no focused text element, the element is a secure field
+    /// (never read passwords), the value is empty, or the caret sits at the
+    /// very start.
+    private func textBeforeCaret(from appElement: AXUIElement) -> String? {
+        guard let focusedElement = accessibilityElement(
+            from: appElement,
+            attribute: kAXFocusedUIElementAttribute as CFString
+        ) else { return nil }
+        // Secure fields report "AXSecureTextField" as the subrole (native
+        // AppKit) or occasionally as the role itself (some web views).
+        let secureMarker = NSAccessibility.Subrole.secureTextField.rawValue
+        let role = accessibilityRawString(from: focusedElement, attribute: kAXRoleAttribute as CFString)
+        let subrole = accessibilityRawString(from: focusedElement, attribute: kAXSubroleAttribute as CFString)
+        if role == secureMarker || subrole == secureMarker {
+            return nil
+        }
+        guard let value = accessibilityRawString(
+            from: focusedElement,
+            attribute: kAXValueAttribute as CFString
+        ), let selectedRange = accessibilityRange(
+            from: focusedElement,
+            attribute: kAXSelectedTextRangeAttribute as CFString
+        ) else { return nil }
+
+        // With an active selection, the text "before the caret" is the text
+        // before the selection start: dictation replaces the selection.
+        let valueNSString = value as NSString
+        var caret = min(max(selectedRange.location, 0), valueNSString.length)
+        guard caret > 0 else { return nil }
+        // Never split a surrogate pair or composed character sequence.
+        if caret < valueNSString.length {
+            let composed = valueNSString.rangeOfComposedCharacterSequence(at: caret)
+            caret = min(caret, composed.location)
+        }
+        guard caret > 0 else { return nil }
+
+        let captured = String(valueNSString.substring(to: caret).suffix(Self.textBeforeCaretLimit))
+        return captured.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : captured
     }
 
     private func focusedWindowTitle(from appElement: AXUIElement) -> String? {

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -1039,6 +1039,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             bundleIdentifier: nil,
             windowTitle: nil,
             selectedText: nil,
+            textBeforeCaret: nil,
             currentActivity: item.contextSummary
         )
 
@@ -2483,6 +2484,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 bundleIdentifier: context.bundleIdentifier,
                 windowTitle: context.windowTitle,
                 selectedText: context.selectedText,
+                textBeforeCaret: context.textBeforeCaret,
                 contextSummary: context.contextSummary,
                 vocabulary: vocabulary,
                 corrections: corrections.map {
@@ -2930,6 +2932,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             bundleIdentifier: frontmostApp?.bundleIdentifier,
             windowTitle: windowTitle,
             selectedText: nil,
+            textBeforeCaret: nil,
             currentActivity: "Could not refresh app context at stop time; using text-only post-processing."
         )
     }

--- a/Sources/AppleFoundationModelsPostProcessor.swift
+++ b/Sources/AppleFoundationModelsPostProcessor.swift
@@ -34,11 +34,38 @@ struct SmartCleanupRequest: Sendable {
     let bundleIdentifier: String?
     let windowTitle: String?
     let selectedText: String?
+    let textBeforeCaret: String?
     let contextSummary: String
     let vocabulary: [String]
     let corrections: [Correction]
     let outputLanguage: String
     let customInstructions: String
+
+    init(
+        transcript: String,
+        appName: String?,
+        bundleIdentifier: String?,
+        windowTitle: String?,
+        selectedText: String?,
+        textBeforeCaret: String? = nil,
+        contextSummary: String,
+        vocabulary: [String],
+        corrections: [Correction],
+        outputLanguage: String,
+        customInstructions: String
+    ) {
+        self.transcript = transcript
+        self.appName = appName
+        self.bundleIdentifier = bundleIdentifier
+        self.windowTitle = windowTitle
+        self.selectedText = selectedText
+        self.textBeforeCaret = textBeforeCaret
+        self.contextSummary = contextSummary
+        self.vocabulary = vocabulary
+        self.corrections = corrections
+        self.outputLanguage = outputLanguage
+        self.customInstructions = customInstructions
+    }
 }
 
 enum AppWritingContext: String, Equatable, Sendable {
@@ -168,6 +195,7 @@ actor AppleFoundationModelsPostProcessor {
     static let dictationInstructions = """
     Clean literal speech transcripts. Return only cleaned text. Make minimum edits. Preserve every clear idea, clause, request, hedge, tone, and level of detail; never summarize or make the text more direct. “I think we should ship this tomorrow” stays “I think we should ship this tomorrow.” “The command is git push dash dash force with lease, and then check the JSON output” becomes “The command is git push --force-with-lease, and then check the JSON output.”
     Remove only hesitation fillers, stutters, duplicate starts, and abandoned wording. Fix punctuation, capitalization, spacing, and obvious recognition mistakes.
+    When a hint shows text immediately before the cursor, the result continues that text: follow the hint's capitalization directive exactly and never repeat its words. After “I think we should”, “definitely ship it” stays “definitely ship it”; after “Check the logs.”, “the deploy failed” becomes “The deploy failed.”
     Formatting follows the App-aware cleanup hint. Dictated list markers such as “bullet point”, “dash”, or “numbered list” become real list lines and the marker words are never kept: “bullet point wash the dishes bullet point buy coffee” becomes “- Wash the dishes” and “- Buy coffee” on separate lines. Where the hint says structure is welcome, a clearly itemized enumeration like “first…, second…, third…” also becomes a list with one item per line and no ordinal words, keeping any introductory clause (“I want to do three things:”) as a lead-in line above the list. Everywhere else, prose stays prose even when it contains “first” and “second”.
     For explicit self-corrections, delete the abandoned choice and correction marker: “Let's meet Thursday, no actually Wednesday after lunch” becomes “Let's meet Wednesday after lunch.”
     Preserve language, names, technical identifiers, paths, flags, URLs, and profanity. Convert “dash dash force with lease” to “--force-with-lease” and “user underscore id” to “user_id” only when clearly technical.
@@ -244,7 +272,11 @@ actor AppleFoundationModelsPostProcessor {
         let started = ContinuousClock.now
         let responseText = try await respond(session: session, prompt: prompt, timeout: timeout)
         let elapsed = started.duration(to: .now).timeInterval
-        let cleaned = Self.normalizeCommandOutput(responseText)
+        var cleaned = Self.normalizeCommandOutput(responseText)
+        if let before = request.textBeforeCaret {
+            cleaned = Self.stripRepeatedCaretPrefix(cleaned, before: before)
+        }
+        cleaned = Self.harmonizeCaseWithCaretContext(cleaned, request: request)
         try Self.validate(cleaned, source: request.transcript)
         return SmartCleanupResponse(text: cleaned, prompt: prompt, elapsed: elapsed)
     }
@@ -574,6 +606,23 @@ actor AppleFoundationModelsPostProcessor {
         if let selected = request.selectedText?.trimmingCharacters(in: .whitespacesAndNewlines), !selected.isEmpty {
             hints.append("Nearby selected text (spelling/tone hint only): \(selected.prefix(300))")
         }
+        if let rawBefore = request.textBeforeCaret {
+            let before = rawBefore
+                .replacingOccurrences(of: "\r\n", with: " ")
+                .replacingOccurrences(of: "\n", with: " ")
+                .replacingOccurrences(of: "\r", with: " ")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .suffix(240)
+            if !before.isEmpty {
+                // The on-device model follows a concrete directive far more
+                // reliably than a conditional rule, so the mid-sentence vs.
+                // new-sentence branch is decided here, not in the prompt.
+                let directive = caretContinuesSentence(rawBefore)
+                    ? "the transcript continues it mid-sentence: start lowercase, no leading period, match its flow"
+                    : "it ends a sentence, so the transcript begins a new sentence: capitalize its first word (“the deploy failed” becomes “The deploy failed”)"
+                hints.append("Text immediately before the cursor (never repeat it): \"\(before)\" — \(directive).")
+            }
+        }
         if !request.contextSummary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             hints.append("Local activity hint: \(request.contextSummary.prefix(240))")
         }
@@ -597,6 +646,98 @@ actor AppleFoundationModelsPostProcessor {
         \(request.transcript)
         </transcript>
         """
+    }
+
+    /// Despite the hint's "never repeat it", the on-device model sometimes
+    /// glues the before-caret text onto the front of its output. Strip it
+    /// deterministically: when the output's opening words match a suffix of
+    /// the before-caret text, drop them. Conservative on purpose — at least
+    /// three words must match, or the entire before-caret text (two words
+    /// minimum), so deliberately re-dictated short phrases survive.
+    static func stripRepeatedCaretPrefix(_ text: String, before: String) -> String {
+        let beforeWords = wordRanges(of: before).map { before[$0].lowercased() }
+        let outputWordRanges = wordRanges(of: text)
+        var matched = 0
+        for k in stride(from: min(beforeWords.count, outputWordRanges.count), through: 1, by: -1) {
+            let head = outputWordRanges.prefix(k).map { text[$0].lowercased() }
+            if Array(beforeWords.suffix(k)) == head {
+                matched = k
+                break
+            }
+        }
+        guard matched >= 3 || (matched == beforeWords.count && matched >= 2) else { return text }
+        let separators: Set<Character> = [",", ";", ":", "—", "–", "-"]
+        let rest = text[outputWordRanges[matched - 1].upperBound...]
+            .drop(while: { $0.isWhitespace || separators.contains($0) })
+        return rest.isEmpty ? text : String(rest)
+    }
+
+    private static func wordRanges(of text: String) -> [Range<String.Index>] {
+        var ranges: [Range<String.Index>] = []
+        var wordStart: String.Index?
+        var index = text.startIndex
+        while index < text.endIndex {
+            let character = text[index]
+            let isWordCharacter = character.isLetter || character.isNumber
+                || character == "'" || character == "’"
+            if isWordCharacter {
+                if wordStart == nil { wordStart = index }
+            } else if let start = wordStart {
+                ranges.append(start..<index)
+                wordStart = nil
+            }
+            index = text.index(after: index)
+        }
+        if let start = wordStart {
+            ranges.append(start..<text.endIndex)
+        }
+        return ranges
+    }
+
+    /// The on-device model's casing is unreliable at the seam between existing
+    /// text and the new dictation, so the first letter is harmonized
+    /// deterministically. After a finished sentence the first word is safely
+    /// capitalized; mid-sentence it is lowercased, but only when the speaker's
+    /// own transcript used the word in lowercase, so proper nouns and "I"
+    /// keep their capitals.
+    static func harmonizeCaseWithCaretContext(_ text: String, request: SmartCleanupRequest) -> String {
+        guard let before = request.textBeforeCaret,
+              !before.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let first = text.first else {
+            return text
+        }
+
+        if caretContinuesSentence(before) {
+            guard first.isUppercase else { return text }
+            let firstWord = text.prefix(while: { $0.isLetter || $0 == "'" || $0 == "’" })
+            guard firstWord.dropFirst().allSatisfy({ !$0.isUppercase }) else { return text }
+            let transcriptWords = request.transcript.split(whereSeparator: {
+                !($0.isLetter || $0 == "'" || $0 == "’")
+            })
+            guard transcriptWords.contains(where: { $0 == firstWord.lowercased() }) else { return text }
+            return first.lowercased() + text.dropFirst()
+        }
+
+        guard first.isLowercase else { return text }
+        // A mixed-case first word ("iPhone") is deliberate; leave it alone.
+        let firstWord = text.prefix(while: { $0.isLetter || $0 == "'" || $0 == "’" })
+        guard firstWord.dropFirst().allSatisfy({ !$0.isUppercase }) else { return text }
+        return first.uppercased() + text.dropFirst()
+    }
+
+    /// Whether text captured before the caret ends mid-sentence, so dictation
+    /// continues it, rather than after sentence punctuation or a line break,
+    /// where dictation starts a fresh sentence.
+    static func caretContinuesSentence(_ textBeforeCaret: String) -> Bool {
+        if textBeforeCaret.reversed().prefix(while: \.isWhitespace).contains(where: \.isNewline) {
+            return false
+        }
+        var scan = Substring(textBeforeCaret.trimmingCharacters(in: .whitespacesAndNewlines))
+        while let last = scan.last, "\"'”’)]".contains(last) {
+            scan = scan.dropLast()
+        }
+        guard let last = scan.last else { return false }
+        return !".!?…".contains(last)
     }
 
     private static func validate(_ output: String, source: String, allowsExpansion: Bool = false) throws {

--- a/Tests/AppContextServiceTests.swift
+++ b/Tests/AppContextServiceTests.swift
@@ -11,6 +11,9 @@ struct AppContextServiceTests {
         testAppWritingContextClassification()
         testMarkdownSurfaceDetection()
         testCleanupPromptUsesLocalAppStyle()
+        testCleanupPromptIncludesTextBeforeCaret()
+        testCaretContextCaseHarmonization()
+        testCaretContextRepetitionStripping()
         testSelectionPromptUsesDestinationContext()
         TranscriptTidierTests.run()
         DictionaryStoreTests.run()
@@ -209,6 +212,181 @@ struct AppContextServiceTests {
         expect(prompt.contains("Writing context: work chat"), "Cleanup prompt lost Slack context")
         expect(prompt.contains("concise, professional chat formatting"), "Slack cleanup guidance missing")
         expect(prompt.contains("do not make the message more formal unless asked"), "Cleanup should preserve tone")
+    }
+
+    private static func testCleanupPromptIncludesTextBeforeCaret() {
+        func request(textBeforeCaret: String?) -> SmartCleanupRequest {
+            SmartCleanupRequest(
+                transcript: "definitely ship it tomorrow",
+                appName: "Notes",
+                bundleIdentifier: "com.apple.Notes",
+                windowTitle: "Ideas",
+                selectedText: nil,
+                textBeforeCaret: textBeforeCaret,
+                contextSummary: "",
+                vocabulary: [],
+                corrections: [],
+                outputLanguage: "",
+                customInstructions: ""
+            )
+        }
+        let hintMarker = "Text immediately before the cursor"
+
+        let withCaretContext = AppleFoundationModelsPostProcessor.cleanupPrompt(
+            for: request(textBeforeCaret: "I think we should")
+        )
+        expect(withCaretContext.contains(hintMarker), "Caret context hint missing")
+        expect(withCaretContext.contains("\"I think we should\""), "Caret context text missing from hint")
+        expect(withCaretContext.contains("start lowercase"), "Mid-sentence caret context must direct a lowercase continuation")
+
+        let afterSentence = AppleFoundationModelsPostProcessor.cleanupPrompt(
+            for: request(textBeforeCaret: "Let me check the logs.")
+        )
+        expect(afterSentence.contains("capitalize its first word"), "Sentence-ending caret context must direct a fresh sentence")
+
+        let multiline = AppleFoundationModelsPostProcessor.cleanupPrompt(
+            for: request(textBeforeCaret: "Meeting notes:\nI think we should")
+        )
+        expect(multiline.contains("\"Meeting notes: I think we should\""), "Caret context must be flattened to one line")
+
+        expect(
+            AppleFoundationModelsPostProcessor.caretContinuesSentence("I think we should"),
+            "Mid-sentence text must continue the sentence"
+        )
+        expect(
+            AppleFoundationModelsPostProcessor.caretContinuesSentence("We talked it over and,"),
+            "A trailing comma must continue the sentence"
+        )
+        expect(
+            !AppleFoundationModelsPostProcessor.caretContinuesSentence("Let me check the logs."),
+            "A trailing period must start a fresh sentence"
+        )
+        expect(
+            !AppleFoundationModelsPostProcessor.caretContinuesSentence("Really?!"),
+            "Trailing sentence punctuation must start a fresh sentence"
+        )
+        expect(
+            !AppleFoundationModelsPostProcessor.caretContinuesSentence("He said \u{201C}done.\u{201D}"),
+            "A period inside closing quotes must start a fresh sentence"
+        )
+        expect(
+            !AppleFoundationModelsPostProcessor.caretContinuesSentence("Shopping list\n"),
+            "A trailing newline must start a fresh sentence"
+        )
+
+        let withoutCaretContext = AppleFoundationModelsPostProcessor.cleanupPrompt(
+            for: request(textBeforeCaret: nil)
+        )
+        expect(!withoutCaretContext.contains(hintMarker), "Caret context hint must be omitted when nil")
+
+        let withBlankCaretContext = AppleFoundationModelsPostProcessor.cleanupPrompt(
+            for: request(textBeforeCaret: "  \n ")
+        )
+        expect(!withBlankCaretContext.contains(hintMarker), "Caret context hint must be omitted when blank")
+
+        // Existing call sites that never pass textBeforeCaret keep compiling
+        // and produce no caret hint.
+        let defaulted = AppleFoundationModelsPostProcessor.cleanupPrompt(for: SmartCleanupRequest(
+            transcript: "definitely ship it tomorrow",
+            appName: "Notes",
+            bundleIdentifier: "com.apple.Notes",
+            windowTitle: "Ideas",
+            selectedText: nil,
+            contextSummary: "",
+            vocabulary: [],
+            corrections: [],
+            outputLanguage: "",
+            customInstructions: ""
+        ))
+        expect(!defaulted.contains(hintMarker), "Defaulted textBeforeCaret must omit the caret hint")
+    }
+
+    private static func testCaretContextCaseHarmonization() {
+        func harmonized(_ text: String, transcript: String, before: String?) -> String {
+            AppleFoundationModelsPostProcessor.harmonizeCaseWithCaretContext(text, request: SmartCleanupRequest(
+                transcript: transcript,
+                appName: nil,
+                bundleIdentifier: nil,
+                windowTitle: nil,
+                selectedText: nil,
+                textBeforeCaret: before,
+                contextSummary: "",
+                vocabulary: [],
+                corrections: [],
+                outputLanguage: "",
+                customInstructions: ""
+            ))
+        }
+
+        expectEqual(
+            harmonized("Definitely ship it", transcript: "um definitely ship it", before: "I think we should"),
+            "definitely ship it"
+        )
+        expectEqual(
+            harmonized("Ian should go", transcript: "Ian should go", before: "I think"),
+            "Ian should go"
+        )
+        expectEqual(
+            harmonized("I should go", transcript: "I should go", before: "maybe"),
+            "I should go"
+        )
+        expectEqual(
+            harmonized("we might need to roll back", transcript: "we might need to roll back", before: "Let me check the logs."),
+            "We might need to roll back"
+        )
+        expectEqual(
+            harmonized("iPhone sales dropped", transcript: "iPhone sales dropped", before: "Let me check the logs."),
+            "iPhone sales dropped"
+        )
+        expectEqual(
+            harmonized("Definitely ship it", transcript: "definitely ship it", before: nil),
+            "Definitely ship it"
+        )
+    }
+
+    private static func testCaretContextRepetitionStripping() {
+        expectEqual(
+            AppleFoundationModelsPostProcessor.stripRepeatedCaretPrefix(
+                "I guess the team could probably try the beta first thing.",
+                before: "I guess the team could"
+            ),
+            "probably try the beta first thing."
+        )
+        expectEqual(
+            AppleFoundationModelsPostProcessor.stripRepeatedCaretPrefix(
+                "I think we should ship",
+                before: "Yesterday we agreed that I think we should"
+            ),
+            "ship"
+        )
+        expectEqual(
+            AppleFoundationModelsPostProcessor.stripRepeatedCaretPrefix(
+                "I guess the team could, probably try the beta",
+                before: "I guess the team could"
+            ),
+            "probably try the beta"
+        )
+        expectEqual(
+            AppleFoundationModelsPostProcessor.stripRepeatedCaretPrefix(
+                "should we reconsider",
+                before: "I think we should"
+            ),
+            "should we reconsider"
+        )
+        expectEqual(
+            AppleFoundationModelsPostProcessor.stripRepeatedCaretPrefix(
+                "hi everyone",
+                before: "Hi"
+            ),
+            "hi everyone"
+        )
+        expectEqual(
+            AppleFoundationModelsPostProcessor.stripRepeatedCaretPrefix(
+                "I guess the team could",
+                before: "I guess the team could"
+            ),
+            "I guess the team could"
+        )
     }
 
     private static func testSelectionPromptUsesDestinationContext() {


### PR DESCRIPTION
Course correction: dictating mid-sentence no longer produces wrong capitalization at the seam.

- `AppContext.textBeforeCaret`: ≤240 chars before the caret from the focused element (AX value + selected range), surrogate-pair-safe; nil for secure fields (role AND subrole checked), empty values, or caret at 0.
- Cleanup prompt gains a one-line hint whose directive is decided in Swift (`caretContinuesSentence`): continue lowercase mid-sentence vs start a new sentence.
- Key finding: the small model was not reliable at the seam from prompts alone — casing and dedup are guaranteed by deterministic, unit-tested post-passes (`stripRepeatedCaretPrefix`, `harmonizeCaseWithCaretContext`), both gated on caret context being present.
- Baseline-verified: without caret context, output is byte-for-byte identical to current main.

Live-validated on-device (3/3 stable): "I think we should" + "definitely ship it" → stays lowercase; "Check the logs." + "we might need to roll back" → capitalized; proper nouns and "I" survive lowercasing.

Verified on macOS 26.5 (arm64): `make test` passes, full build clean. Manual QA: quirky AX trees (Electron) degrade to nil → unchanged behavior.
---
*All eight feature PRs register tests in `Tests/AppContextServiceTests.swift` and some extend the Makefile test list, so each merge after the first needs a trivial conflict resolution there. Suggested merge order: dictionary-ranking → formality-dial → caret-context → transforms → scratch-that → raw-undo → rebindable-cancel → mouse-ptt.*
