### PR TITLE
Make the dictation cancel key rebindable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,14 +104,14 @@ endif
 test: $(TEST_RUNNER)
 	@$(TEST_RUNNER)
 
-$(TEST_RUNNER): Sources/AppContextService.swift Sources/AppleFoundationModelsPostProcessor.swift Sources/DictionaryStore.swift Sources/TranscriptTidier.swift Sources/WakePhraseMatcher.swift Tests/AppContextServiceTests.swift Tests/DictionaryStoreTests.swift Tests/TranscriptTidierTests.swift Tests/WakePhraseMatcherTests.swift
+$(TEST_RUNNER): Sources/AppContextService.swift Sources/AppleFoundationModelsPostProcessor.swift Sources/DictionaryStore.swift Sources/ShortcutCore/ShortcutModels.swift Sources/TranscriptTidier.swift Sources/WakePhraseMatcher.swift Tests/AppContextServiceTests.swift Tests/DictionaryStoreTests.swift Tests/ShortcutCancelBindingTests.swift Tests/TranscriptTidierTests.swift Tests/WakePhraseMatcherTests.swift
 	@mkdir -p "$(BUILD_DIR)"
 	swiftc \
 		-parse-as-library \
 		-o "$(TEST_RUNNER)" \
 		-sdk $(shell xcrun --show-sdk-path) \
 		-target $(ARCH)-apple-macosx26.0 \
-		Sources/AppContextService.swift Sources/AppleFoundationModelsPostProcessor.swift Sources/DictionaryStore.swift Sources/TranscriptTidier.swift Sources/WakePhraseMatcher.swift Tests/AppContextServiceTests.swift Tests/DictionaryStoreTests.swift Tests/TranscriptTidierTests.swift Tests/WakePhraseMatcherTests.swift
+		Sources/AppContextService.swift Sources/AppleFoundationModelsPostProcessor.swift Sources/DictionaryStore.swift Sources/ShortcutCore/ShortcutModels.swift Sources/TranscriptTidier.swift Sources/WakePhraseMatcher.swift Tests/AppContextServiceTests.swift Tests/DictionaryStoreTests.swift Tests/ShortcutCancelBindingTests.swift Tests/TranscriptTidierTests.swift Tests/WakePhraseMatcherTests.swift
 
 icon: $(ICON_ICNS)
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -220,9 +220,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let holdShortcutStorageKey = "hold_shortcut"
     private let toggleShortcutStorageKey = "toggle_shortcut"
     private let copyAgainShortcutStorageKey = "copy_again_shortcut"
+    private let cancelShortcutStorageKey = "cancel_shortcut"
     private let savedHoldCustomShortcutStorageKey = "saved_hold_custom_shortcut"
     private let savedToggleCustomShortcutStorageKey = "saved_toggle_custom_shortcut"
     private let savedCopyAgainCustomShortcutStorageKey = "saved_copy_again_custom_shortcut"
+    private let savedCancelCustomShortcutStorageKey = "saved_cancel_custom_shortcut"
     private let customVocabularyStorageKey = "custom_vocabulary"
     private let wordCorrectionsStorageKey = "word_corrections"
     private let smartCleanupModeStorageKey = "smart_cleanup_mode"
@@ -287,6 +289,13 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
+    @Published var cancelShortcut: ShortcutBinding {
+        didSet {
+            persistShortcut(cancelShortcut, key: cancelShortcutStorageKey)
+            restartHotkeyMonitoring()
+        }
+    }
+
     @Published private(set) var savedHoldCustomShortcut: ShortcutBinding? {
         didSet {
             persistOptionalShortcut(savedHoldCustomShortcut, key: savedHoldCustomShortcutStorageKey)
@@ -302,6 +311,12 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published private(set) var savedCopyAgainCustomShortcut: ShortcutBinding? {
         didSet {
             persistOptionalShortcut(savedCopyAgainCustomShortcut, key: savedCopyAgainCustomShortcutStorageKey)
+        }
+    }
+
+    @Published private(set) var savedCancelCustomShortcut: ShortcutBinding? {
+        didSet {
+            persistOptionalShortcut(savedCancelCustomShortcut, key: savedCancelCustomShortcutStorageKey)
         }
     }
 
@@ -605,7 +620,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let shortcuts = Self.loadShortcutConfiguration(
             holdKey: holdShortcutStorageKey,
             toggleKey: toggleShortcutStorageKey,
-            copyAgainKey: copyAgainShortcutStorageKey
+            copyAgainKey: copyAgainShortcutStorageKey,
+            cancelKey: cancelShortcutStorageKey
         )
         let savedHoldCustomShortcut = Self.loadSavedCustomShortcut(
             forKey: savedHoldCustomShortcutStorageKey,
@@ -618,6 +634,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let savedCopyAgainCustomShortcut = Self.loadSavedCustomShortcut(
             forKey: savedCopyAgainCustomShortcutStorageKey,
             fallback: shortcuts.copyAgain.isCustom ? shortcuts.copyAgain : nil
+        )
+        let savedCancelCustomShortcut = Self.loadSavedCustomShortcut(
+            forKey: savedCancelCustomShortcutStorageKey,
+            fallback: shortcuts.cancel != .defaultCancel ? shortcuts.cancel : nil
         )
         let customVocabulary = UserDefaults.standard.string(forKey: customVocabularyStorageKey) ?? ""
         let wordCorrections = UserDefaults.standard.string(forKey: wordCorrectionsStorageKey) ?? ""
@@ -703,9 +723,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.holdShortcut = shortcuts.hold
         self.toggleShortcut = shortcuts.toggle
         self.copyAgainShortcut = shortcuts.copyAgain
+        self.cancelShortcut = shortcuts.cancel
         self.savedHoldCustomShortcut = savedHoldCustomShortcut.binding
         self.savedToggleCustomShortcut = savedToggleCustomShortcut.binding
         self.savedCopyAgainCustomShortcut = savedCopyAgainCustomShortcut.binding
+        self.savedCancelCustomShortcut = savedCancelCustomShortcut.binding
         self.isCommandModeEnabled = isCommandModeEnabled
         self.commandModeStyle = commandModeStyle
         self.commandModeManualModifier = commandModeManualModifier
@@ -753,6 +775,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         if shortcuts.didUpdateCopyAgainStoredValue {
             persistShortcut(shortcuts.copyAgain, key: copyAgainShortcutStorageKey)
         }
+        if shortcuts.didUpdateCancelStoredValue {
+            persistShortcut(shortcuts.cancel, key: cancelShortcutStorageKey)
+        }
         if savedHoldCustomShortcut.didUpdateStoredValue {
             persistOptionalShortcut(savedHoldCustomShortcut.binding, key: savedHoldCustomShortcutStorageKey)
         }
@@ -761,6 +786,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
         if savedCopyAgainCustomShortcut.didUpdateStoredValue {
             persistOptionalShortcut(savedCopyAgainCustomShortcut.binding, key: savedCopyAgainCustomShortcutStorageKey)
+        }
+        if savedCancelCustomShortcut.didUpdateStoredValue {
+            persistOptionalShortcut(savedCancelCustomShortcut.binding, key: savedCancelCustomShortcutStorageKey)
         }
 
         overlayManager.onStopButtonPressed = { [weak self] in
@@ -814,9 +842,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let hold: ShortcutBinding
         let toggle: ShortcutBinding
         let copyAgain: ShortcutBinding
+        let cancel: ShortcutBinding
         let didUpdateHoldStoredValue: Bool
         let didUpdateToggleStoredValue: Bool
         let didUpdateCopyAgainStoredValue: Bool
+        let didUpdateCancelStoredValue: Bool
     }
 
     private struct StoredOptionalShortcut {
@@ -833,7 +863,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private static func loadShortcutConfiguration(
         holdKey: String,
         toggleKey: String,
-        copyAgainKey: String
+        copyAgainKey: String,
+        cancelKey: String
     ) -> StoredShortcutConfiguration {
         let legacyPreset = ShortcutPreset(
             rawValue: UserDefaults.standard.string(forKey: "hotkey_option") ?? ShortcutPreset.fnKey.rawValue
@@ -843,13 +874,18 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let storedHold = loadShortcut(forKey: holdKey)
         let storedToggle = loadShortcut(forKey: toggleKey)
         let storedCopyAgain = loadShortcut(forKey: copyAgainKey)
+        let storedCancel = loadShortcut(forKey: cancelKey)
+        let cancel = ShortcutBinding.sanitizedCancelBinding(storedCancel.binding)
         return StoredShortcutConfiguration(
             hold: storedHold.binding ?? hold,
             toggle: storedToggle.binding ?? toggle,
             copyAgain: storedCopyAgain.binding ?? .disabled,
+            cancel: cancel,
             didUpdateHoldStoredValue: storedHold.binding == nil || storedHold.didNormalize,
             didUpdateToggleStoredValue: storedToggle.binding == nil || storedToggle.didNormalize,
-            didUpdateCopyAgainStoredValue: storedCopyAgain.didNormalize
+            didUpdateCopyAgainStoredValue: storedCopyAgain.didNormalize,
+            didUpdateCancelStoredValue: storedCancel.didNormalize
+                || (storedCancel.binding != nil && cancel != storedCancel.binding)
         )
     }
 
@@ -1322,7 +1358,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
     }
 
     var usesFnShortcut: Bool {
-        holdShortcut.usesFnKey || toggleShortcut.usesFnKey || copyAgainShortcut.usesFnKey
+        holdShortcut.usesFnKey || toggleShortcut.usesFnKey || copyAgainShortcut.usesFnKey || cancelShortcut.usesFnKey
     }
 
     var hasEnabledHoldShortcut: Bool {
@@ -1362,6 +1398,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
             return savedToggleCustomShortcut
         case .copyAgain:
             return savedCopyAgainCustomShortcut
+        case .cancel:
+            return savedCancelCustomShortcut
         }
     }
 
@@ -1409,10 +1447,27 @@ final class AppState: ObservableObject, @unchecked Sendable {
             }
         }
 
+        if role == .cancel {
+            guard binding.kind == .key else {
+                return "Cancel Dictation must use a regular key, optionally with modifiers."
+            }
+            if binding.conflicts(with: holdShortcut) {
+                return "Cancel Dictation cannot share a shortcut with Hold to Talk."
+            }
+            if binding.conflicts(with: toggleShortcut) {
+                return "Cancel Dictation cannot share a shortcut with Tap to Toggle."
+            }
+        }
+        if role != .cancel, role != .copyAgain, binding.conflicts(with: cancelShortcut) {
+            return "This shortcut is already used by Cancel Dictation."
+        }
         if role != .copyAgain, binding.conflicts(with: copyAgainShortcut) {
             return "This shortcut is already used by Paste Again."
         }
         if role == .copyAgain {
+            if binding.conflicts(with: cancelShortcut) {
+                return "Paste Again cannot share a shortcut with Cancel Dictation."
+            }
             if binding.conflicts(with: holdShortcut) {
                 return "Paste Again cannot share a shortcut with Hold to Talk."
             }
@@ -1441,6 +1496,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 savedCopyAgainCustomShortcut = binding
             }
             copyAgainShortcut = binding
+        case .cancel:
+            if binding != .defaultCancel {
+                savedCancelCustomShortcut = binding
+            }
+            cancelShortcut = binding
         }
 
         return nil
@@ -1508,8 +1568,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 self?.handleShortcutEvent(event)
             }
         }
-        hotkeyManager.onEscapeKeyPressed = { [weak self] in
-            self?.handleEscapeKeyPress() ?? false
+        hotkeyManager.onCancelKeyPressed = { [weak self] in
+            self?.handleCancelKeyPress() ?? false
         }
         restartHotkeyMonitoring()
     }
@@ -1518,7 +1578,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         shouldMonitorHotkeys = false
         hotkeyMonitoringErrorMessage = nil
         hotkeyManager.onShortcutEvent = nil
-        hotkeyManager.onEscapeKeyPressed = nil
+        hotkeyManager.onCancelKeyPressed = nil
         hotkeyManager.stop()
     }
 
@@ -1544,6 +1604,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
             hold: holdShortcut,
             toggle: toggleShortcut,
             copyAgain: copyAgainShortcut,
+            cancel: cancelShortcut,
             permittedAdditionalExactMatchModifiers: permittedAdditionalExactMatchModifiers
         )
     }
@@ -1595,7 +1656,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
     }
 
-    private func handleEscapeKeyPress() -> Bool {
+    /// Consumes the configured cancel key only while a session it can cancel
+    /// is active (transcribing, or a pending/active toggle dictation). In
+    /// every other situation this returns false and the key event passes
+    /// through to the frontmost app untouched.
+    private func handleCancelKeyPress() -> Bool {
         if isTranscribing {
             cancelTranscription()
             return true

--- a/Sources/GlobalShortcutBackend.swift
+++ b/Sources/GlobalShortcutBackend.swift
@@ -23,7 +23,12 @@ final class GlobalShortcutBackend {
     private var fnKeyIsDown = false
 
     var onInputEvent: ((ShortcutInputEvent) -> ShortcutConsumeDecision)?
-    var onEscapeKeyPressed: (() -> Bool)?
+    var onCancelKeyPressed: (() -> Bool)?
+    /// The binding that cancels an active dictation session. Only consulted on
+    /// key-down; the event is swallowed only when `onCancelKeyPressed` reports
+    /// that a session was actually cancelled, so the key types normally the
+    /// rest of the time.
+    var cancelBinding: ShortcutBinding = .defaultCancel
 
     func start() throws {
         stop()
@@ -147,9 +152,15 @@ final class GlobalShortcutBackend {
     }
 
     private func handleKeyDown(_ event: NSEvent) -> Bool {
-        if event.keyCode == 53 {
+        let activeModifiers = ShortcutBinding.modifiers(
+            for: ModifierKeyEventState.pressedModifierKeyCodes(
+                for: event,
+                trustedFunctionKeyIsDown: fnKeyIsDown
+            )
+        )
+        if cancelBinding.matchesCancelKeyDown(keyCode: event.keyCode, activeModifiers: activeModifiers) {
             guard !event.isARepeat else { return false }
-            return onEscapeKeyPressed?() ?? false
+            return onCancelKeyPressed?() ?? false
         }
 
         guard !ShortcutBinding.modifierKeyCodes.contains(event.keyCode) else { return false }

--- a/Sources/HotkeyManager.swift
+++ b/Sources/HotkeyManager.swift
@@ -9,7 +9,7 @@ final class HotkeyManager {
     private var inputState = ShortcutInputState()
 
     var onShortcutEvent: ((ShortcutEvent) -> Void)?
-    var onEscapeKeyPressed: (() -> Bool)?
+    var onCancelKeyPressed: (() -> Bool)?
 
     var currentPressedModifiers: ShortcutModifiers {
         inputState.currentModifiers
@@ -25,14 +25,15 @@ final class HotkeyManager {
         backend.onInputEvent = { [weak self] event in
             self?.handleInputEvent(event) ?? .passthrough
         }
-        backend.onEscapeKeyPressed = { [weak self] in
-            self?.onEscapeKeyPressed?() ?? false
+        backend.onCancelKeyPressed = { [weak self] in
+            self?.onCancelKeyPressed?() ?? false
         }
+        backend.cancelBinding = ShortcutBinding.sanitizedCancelBinding(configuration.cancel)
         do {
             try backend.start()
         } catch {
             backend.onInputEvent = nil
-            backend.onEscapeKeyPressed = nil
+            backend.onCancelKeyPressed = nil
             inputState = ShortcutInputState()
             throw error
         }
@@ -41,7 +42,7 @@ final class HotkeyManager {
     func stop() {
         backend.stop()
         backend.onInputEvent = nil
-        backend.onEscapeKeyPressed = nil
+        backend.onCancelKeyPressed = nil
         inputState = ShortcutInputState()
     }
 

--- a/Sources/ShortcutComponents.swift
+++ b/Sources/ShortcutComponents.swift
@@ -11,6 +11,7 @@ struct DictationShortcutEditor: View {
     @State private var holdValidationMessage: String?
     @State private var toggleValidationMessage: String?
     @State private var copyAgainValidationMessage: String?
+    @State private var cancelValidationMessage: String?
 
     init(showsIntroText: Bool = true, onCaptureStateChange: ((Bool) -> Void)? = nil) {
         self.showsIntroText = showsIntroText
@@ -70,6 +71,18 @@ struct DictationShortcutEditor: View {
                 }
             )
 
+            CancelShortcutSection(
+                selection: appState.cancelShortcut,
+                validationMessage: cancelValidationMessage,
+                isCapturing: Binding(
+                    get: { activeCaptureRole == .cancel },
+                    set: { activeCaptureRole = $0 ? .cancel : nil }
+                ),
+                onSelect: { binding in
+                    cancelValidationMessage = appState.setShortcut(binding, for: .cancel)
+                }
+            )
+
             Text("Custom shortcuts can use regular keys, modifier-only shortcuts, or modifier combinations.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -120,6 +133,50 @@ struct ShortcutRoleSection: View {
                 ShortcutCaptureRow(
                     savedBinding: appState.savedCustomShortcut(for: role),
                     isSelected: selection.isCustom,
+                    isCapturing: $isCapturing,
+                    onSelectSaved: onSelect,
+                    onCapture: onSelect
+                )
+            }
+
+            if let validationMessage, !validationMessage.isEmpty {
+                Label(validationMessage, systemImage: "xmark.circle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+}
+
+/// Settings row for the cancel-dictation key. Unlike the dictation roles it
+/// cannot be disabled and has a single Escape default instead of the preset
+/// list; selecting the default row doubles as reset-to-default.
+struct CancelShortcutSection: View {
+    @EnvironmentObject var appState: AppState
+    let selection: ShortcutBinding
+    let validationMessage: String?
+    @Binding var isCapturing: Bool
+    let onSelect: (ShortcutBinding) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(ShortcutRole.cancel.title)
+                .font(.subheadline.weight(.semibold))
+
+            Text("Press this key while dictating or transcribing to cancel without pasting.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            VStack(spacing: 6) {
+                ShortcutPresetRow(
+                    title: "Esc (Default)",
+                    isSelected: selection == .defaultCancel,
+                    action: { onSelect(.defaultCancel) }
+                )
+
+                ShortcutCaptureRow(
+                    savedBinding: appState.savedCustomShortcut(for: .cancel),
+                    isSelected: selection != .defaultCancel,
                     isCapturing: $isCapturing,
                     onSelectSaved: onSelect,
                     onCapture: onSelect

--- a/Sources/ShortcutCore/ShortcutModels.swift
+++ b/Sources/ShortcutCore/ShortcutModels.swift
@@ -56,12 +56,14 @@ enum ShortcutRole {
     case hold
     case toggle
     case copyAgain
+    case cancel
 
     var title: String {
         switch self {
         case .hold: return "Hold to Talk"
         case .toggle: return "Tap to Toggle"
         case .copyAgain: return "Paste Again"
+        case .cancel: return "Cancel Dictation"
         }
     }
 }
@@ -78,17 +80,20 @@ struct ShortcutConfiguration: Equatable {
     let hold: ShortcutBinding
     let toggle: ShortcutBinding
     let copyAgain: ShortcutBinding
+    let cancel: ShortcutBinding
     let permittedAdditionalExactMatchModifiers: ShortcutModifiers
 
     init(
         hold: ShortcutBinding,
         toggle: ShortcutBinding,
         copyAgain: ShortcutBinding = .disabled,
+        cancel: ShortcutBinding = .defaultCancel,
         permittedAdditionalExactMatchModifiers: ShortcutModifiers = []
     ) {
         self.hold = hold
         self.toggle = toggle
         self.copyAgain = copyAgain
+        self.cancel = cancel
         self.permittedAdditionalExactMatchModifiers = permittedAdditionalExactMatchModifiers
     }
 
@@ -334,6 +339,24 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
         }
     }
 
+    /// True when a key-down for `keyCode` with `activeModifiers` held should
+    /// trigger this binding as the cancel key. The binding's modifiers must be
+    /// a subset of the active ones (rather than an exact match) so the default
+    /// Escape binding keeps the historical behavior of cancelling even when
+    /// extra modifiers happen to be held.
+    func matchesCancelKeyDown(keyCode: UInt16, activeModifiers: ShortcutModifiers) -> Bool {
+        guard kind == .key else { return false }
+        return self.keyCode == keyCode && activeModifiers.isSuperset(of: modifiers)
+    }
+
+    /// Cancel bindings must be regular-key bindings so they can be matched on
+    /// key-down events. Anything else (nil, disabled, modifier-only, corrupt
+    /// storage) falls back to the default Escape binding.
+    static func sanitizedCancelBinding(_ binding: ShortcutBinding?) -> ShortcutBinding {
+        guard let binding, binding.kind == .key else { return .defaultCancel }
+        return binding
+    }
+
     static let disabled = ShortcutBinding(
         keyCode: 0,
         keyDisplay: "Disabled",
@@ -343,6 +366,13 @@ struct ShortcutBinding: Codable, Hashable, Identifiable, Equatable {
     )
     static let defaultHold = ShortcutPreset.fnKey.binding
     static let defaultToggle = ShortcutPreset.fnKey.binding.withAddedModifiers(.command)
+    static let defaultCancel = ShortcutBinding(
+        keyCode: 53,
+        keyDisplay: "Esc",
+        modifiers: [],
+        kind: .key,
+        preset: nil
+    )
 
     static let modifierKeyCodes: Set<UInt16> = [54, 55, 56, 58, 59, 60, 61, 62, 63]
 

--- a/Tests/AppContextServiceTests.swift
+++ b/Tests/AppContextServiceTests.swift
@@ -15,6 +15,7 @@ struct AppContextServiceTests {
         TranscriptTidierTests.run()
         DictionaryStoreTests.run()
         WakePhraseMatcherTests.run()
+        ShortcutCancelBindingTests.run()
         print("MegaphoneTests passed")
     }
 

--- a/Tests/ShortcutCancelBindingTests.swift
+++ b/Tests/ShortcutCancelBindingTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+
+struct ShortcutCancelBindingTests {
+    static func run() {
+        testDefaultCancelIsBareEscapeKey()
+        testDefaultCancelEncodeDecodeRoundTrip()
+        testCustomCancelEncodeDecodeRoundTrip()
+        testCorruptStoredDataFailsDecodingGracefully()
+        testSanitizedCancelBindingFallsBackToDefault()
+        testSanitizedCancelBindingKeepsValidKeyBindings()
+        testCancelKeyDownMatching()
+        testConfigurationDefaultsCancelToEscape()
+    }
+
+    private static let customCancel = ShortcutBinding(
+        keyCode: 47,
+        keyDisplay: ".",
+        modifiers: [.command],
+        kind: .key,
+        preset: nil
+    )
+
+    private static func testDefaultCancelIsBareEscapeKey() {
+        let binding = ShortcutBinding.defaultCancel
+        expect(binding.keyCode == 53, "Default cancel key must be Escape (keyCode 53)")
+        expect(binding.modifiers == [], "Default cancel key must have no modifiers")
+        expect(binding.kind == .key, "Default cancel key must be a regular key binding")
+        expect(!binding.isDisabled, "Default cancel key must not be disabled")
+    }
+
+    private static func testDefaultCancelEncodeDecodeRoundTrip() {
+        expectRoundTrips(.defaultCancel)
+    }
+
+    private static func testCustomCancelEncodeDecodeRoundTrip() {
+        expectRoundTrips(customCancel)
+
+        let withExactModifiers = ShortcutBinding(
+            keyCode: 96,
+            keyDisplay: "F5",
+            modifiers: [.control, .shift],
+            kind: .key,
+            preset: nil,
+            exactModifierKeyCodes: [59, 56]
+        )
+        expectRoundTrips(withExactModifiers)
+    }
+
+    private static func testCorruptStoredDataFailsDecodingGracefully() {
+        let corrupt = Data("not a shortcut binding".utf8)
+        let decoded = try? JSONDecoder().decode(ShortcutBinding.self, from: corrupt)
+        expect(decoded == nil, "Corrupt stored data must decode to nil, not crash")
+        expect(
+            ShortcutBinding.sanitizedCancelBinding(decoded) == .defaultCancel,
+            "Corrupt stored data must fall back to the default cancel binding"
+        )
+    }
+
+    private static func testSanitizedCancelBindingFallsBackToDefault() {
+        expect(
+            ShortcutBinding.sanitizedCancelBinding(nil) == .defaultCancel,
+            "Missing binding must fall back to default"
+        )
+        expect(
+            ShortcutBinding.sanitizedCancelBinding(.disabled) == .defaultCancel,
+            "Disabled binding must fall back to default"
+        )
+
+        let modifierOnly = ShortcutBinding(
+            keyCode: 63,
+            keyDisplay: "Fn",
+            modifiers: [],
+            kind: .modifierKey,
+            preset: .fnKey
+        )
+        expect(
+            ShortcutBinding.sanitizedCancelBinding(modifierOnly) == .defaultCancel,
+            "Modifier-only binding must fall back to default"
+        )
+    }
+
+    private static func testSanitizedCancelBindingKeepsValidKeyBindings() {
+        expect(
+            ShortcutBinding.sanitizedCancelBinding(customCancel) == customCancel,
+            "Valid key binding must be kept as-is"
+        )
+        expect(
+            ShortcutBinding.sanitizedCancelBinding(.defaultCancel) == .defaultCancel,
+            "Default binding must be kept as-is"
+        )
+    }
+
+    private static func testCancelKeyDownMatching() {
+        let defaultCancel = ShortcutBinding.defaultCancel
+        expect(
+            defaultCancel.matchesCancelKeyDown(keyCode: 53, activeModifiers: []),
+            "Default cancel must match a bare Escape key-down"
+        )
+        // Historical behavior: the hardcoded check consumed Escape regardless
+        // of held modifiers, so a no-modifier binding matches supersets.
+        expect(
+            defaultCancel.matchesCancelKeyDown(keyCode: 53, activeModifiers: [.command, .shift]),
+            "Default cancel must still match Escape with extra modifiers held"
+        )
+        expect(
+            !defaultCancel.matchesCancelKeyDown(keyCode: 49, activeModifiers: []),
+            "Default cancel must not match other keys"
+        )
+
+        expect(
+            customCancel.matchesCancelKeyDown(keyCode: 47, activeModifiers: [.command]),
+            "Custom cancel must match its key with its modifiers held"
+        )
+        expect(
+            customCancel.matchesCancelKeyDown(keyCode: 47, activeModifiers: [.command, .option]),
+            "Custom cancel must match when extra modifiers are held"
+        )
+        expect(
+            !customCancel.matchesCancelKeyDown(keyCode: 47, activeModifiers: []),
+            "Custom cancel must not match without its required modifiers"
+        )
+        expect(
+            !customCancel.matchesCancelKeyDown(keyCode: 53, activeModifiers: [.command]),
+            "Custom cancel must not match a different keyCode"
+        )
+
+        let modifierOnly = ShortcutPreset.fnKey.binding
+        expect(
+            !modifierOnly.matchesCancelKeyDown(keyCode: 63, activeModifiers: [.function]),
+            "Modifier-only bindings must never match as cancel keys"
+        )
+        expect(
+            !ShortcutBinding.disabled.matchesCancelKeyDown(keyCode: 0, activeModifiers: []),
+            "Disabled bindings must never match as cancel keys"
+        )
+    }
+
+    private static func testConfigurationDefaultsCancelToEscape() {
+        let configuration = ShortcutConfiguration(hold: .defaultHold, toggle: .defaultToggle)
+        expect(
+            configuration.cancel == .defaultCancel,
+            "Configurations without an explicit cancel binding must default to Escape"
+        )
+    }
+
+    private static func expectRoundTrips(_ binding: ShortcutBinding, file: StaticString = #file, line: UInt = #line) {
+        guard let data = try? JSONEncoder().encode(binding) else {
+            fatalError("\(file):\(line): Failed to encode \(binding.displayName)")
+        }
+        guard let decoded = try? JSONDecoder().decode(ShortcutBinding.self, from: data) else {
+            fatalError("\(file):\(line): Failed to decode \(binding.displayName)")
+        }
+        expect(decoded == binding, "Round trip changed binding: \(binding.displayName) -> \(decoded.displayName)", file: file, line: line)
+    }
+
+    private static func expect(_ condition: Bool, _ message: String, file: StaticString = #file, line: UInt = #line) {
+        if !condition {
+            fatalError("\(file):\(line): \(message)")
+        }
+    }
+}


### PR DESCRIPTION
The cancel key was hardcoded to Escape in the event tap; it's now a configurable binding (default Escape — behavior unchanged out of the box).

- Reuses `ShortcutBinding` outright (`.key`, keyCode 53, no modifiers) — storage, capture UI, and display come for free; new `ShortcutRole.cancel` + `cancel` slot on `ShortcutConfiguration`.
- Superset modifier matching preserves the old behavior (Cmd+Esc still cancels under the default) while making Cmd+. style bindings work.
- Session scoping preserved exactly: the key is consumed only while transcribing or during a pending/active toggle session, and `sanitizedCancelBinding` guarantees a corrupt/modifier-only stored binding falls back to Esc so typing can never be swallowed.
- Settings: "Cancel Dictation" row with an "Esc (Default)" reset row + the standard capture row; conflict validation against hold/toggle/copy-again.

Verified on macOS 26.5 (arm64): `make test` passes, full build clean. Note for bisects: the backend commit intentionally precedes the AppState rename commit and doesn't compile standalone.

Conflicts: touches `GlobalShortcutBackend`/`HotkeyManager` alongside #mouse-ptt — whichever merges second resolves conflicts (including the `onEscapeKeyPressed` → `onCancelKeyPressed` rename).
---
*All eight feature PRs register tests in `Tests/AppContextServiceTests.swift` and some extend the Makefile test list, so each merge after the first needs a trivial conflict resolution there. Suggested merge order: dictionary-ranking → formality-dial → caret-context → transforms → scratch-that → raw-undo → rebindable-cancel → mouse-ptt.*
