### PR TITLE
Mouse-button push-to-talk (opt-in)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,14 +104,14 @@ endif
 test: $(TEST_RUNNER)
 	@$(TEST_RUNNER)
 
-$(TEST_RUNNER): Sources/AppContextService.swift Sources/AppleFoundationModelsPostProcessor.swift Sources/DictionaryStore.swift Sources/TranscriptTidier.swift Sources/WakePhraseMatcher.swift Tests/AppContextServiceTests.swift Tests/DictionaryStoreTests.swift Tests/TranscriptTidierTests.swift Tests/WakePhraseMatcherTests.swift
+$(TEST_RUNNER): Sources/AppContextService.swift Sources/AppleFoundationModelsPostProcessor.swift Sources/DictionaryStore.swift Sources/ShortcutCore/MouseDictationButton.swift Sources/TranscriptTidier.swift Sources/WakePhraseMatcher.swift Tests/AppContextServiceTests.swift Tests/DictionaryStoreTests.swift Tests/MouseDictationButtonTests.swift Tests/TranscriptTidierTests.swift Tests/WakePhraseMatcherTests.swift
 	@mkdir -p "$(BUILD_DIR)"
 	swiftc \
 		-parse-as-library \
 		-o "$(TEST_RUNNER)" \
 		-sdk $(shell xcrun --show-sdk-path) \
 		-target $(ARCH)-apple-macosx26.0 \
-		Sources/AppContextService.swift Sources/AppleFoundationModelsPostProcessor.swift Sources/DictionaryStore.swift Sources/TranscriptTidier.swift Sources/WakePhraseMatcher.swift Tests/AppContextServiceTests.swift Tests/DictionaryStoreTests.swift Tests/TranscriptTidierTests.swift Tests/WakePhraseMatcherTests.swift
+		Sources/AppContextService.swift Sources/AppleFoundationModelsPostProcessor.swift Sources/DictionaryStore.swift Sources/ShortcutCore/MouseDictationButton.swift Sources/TranscriptTidier.swift Sources/WakePhraseMatcher.swift Tests/AppContextServiceTests.swift Tests/DictionaryStoreTests.swift Tests/MouseDictationButtonTests.swift Tests/TranscriptTidierTests.swift Tests/WakePhraseMatcherTests.swift
 
 icon: $(ICON_ICNS)
 

--- a/Sources/AppState.swift
+++ b/Sources/AppState.swift
@@ -252,6 +252,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private let commandModeManualModifierStorageKey = "command_mode_manual_modifier"
     private let outputLanguageStorageKey = "output_language"
     private let dictationAudioInterruptionEnabledStorageKey = "dictation_audio_interruption_enabled"
+    private let mouseDictationEnabledStorageKey = "mouse_dictation_enabled"
+    private let mouseDictationButtonStorageKey = "mouse_dictation_button"
     private let pasteAfterShortcutReleaseDelay: TimeInterval = 0.03
     private let pressEnterAfterPasteDelay: TimeInterval = 0.08
     private let clipboardRestoreDelay: TimeInterval = 1.0
@@ -302,6 +304,20 @@ final class AppState: ObservableObject, @unchecked Sendable {
     @Published private(set) var savedCopyAgainCustomShortcut: ShortcutBinding? {
         didSet {
             persistOptionalShortcut(savedCopyAgainCustomShortcut, key: savedCopyAgainCustomShortcutStorageKey)
+        }
+    }
+
+    @Published var isMouseDictationEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(isMouseDictationEnabled, forKey: mouseDictationEnabledStorageKey)
+            restartHotkeyMonitoring()
+        }
+    }
+
+    @Published var mouseDictationButton: Int {
+        didSet {
+            UserDefaults.standard.set(mouseDictationButton, forKey: mouseDictationButtonStorageKey)
+            restartHotkeyMonitoring()
         }
     }
 
@@ -593,6 +609,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
     private var shouldMonitorHotkeys = false
     private var isCapturingShortcut = false
     private var isAwaitingMicrophonePermission = false
+    /// True from the configured mouse button's down until its up (or until
+    /// something else ends the session first). Gates which otherMouse events
+    /// the tap consumes and whether the up should stop dictation.
+    private var isMouseHoldSessionActive = false
     private var pendingMicrophonePermissionTriggerMode: RecordingTriggerMode?
     private var pendingMicrophonePermissionSelectionSnapshot: AppSelectionSnapshot?
     private var pendingMicrophonePermissionManualCommandRequested: Bool?
@@ -644,6 +664,11 @@ final class AppState: ObservableObject, @unchecked Sendable {
         let commandModeManualModifier = CommandModeManualModifier(
             rawValue: UserDefaults.standard.string(forKey: commandModeManualModifierStorageKey) ?? ""
         ) ?? .option
+        let isMouseDictationEnabled = UserDefaults.standard.bool(forKey: mouseDictationEnabledStorageKey)
+        let mouseDictationButton = MouseDictationButton.normalized(
+            UserDefaults.standard.object(forKey: mouseDictationButtonStorageKey) as? Int
+                ?? MouseDictationButton.defaultButtonNumber
+        )
         let preserveClipboard = UserDefaults.standard.object(forKey: preserveClipboardStorageKey) == nil
             ? true
             : UserDefaults.standard.bool(forKey: preserveClipboardStorageKey)
@@ -709,6 +734,8 @@ final class AppState: ObservableObject, @unchecked Sendable {
         self.isCommandModeEnabled = isCommandModeEnabled
         self.commandModeStyle = commandModeStyle
         self.commandModeManualModifier = commandModeManualModifier
+        self.isMouseDictationEnabled = isMouseDictationEnabled
+        self.mouseDictationButton = mouseDictationButton
         self.customVocabulary = customVocabulary
         self.wordCorrections = wordCorrections
         self.smartCleanupMode = smartCleanupMode
@@ -1511,6 +1538,9 @@ final class AppState: ObservableObject, @unchecked Sendable {
         hotkeyManager.onEscapeKeyPressed = { [weak self] in
             self?.handleEscapeKeyPress() ?? false
         }
+        hotkeyManager.onMouseButtonEvent = { [weak self] isDown in
+            self?.handleMouseDictationButtonEvent(isDown: isDown) ?? false
+        }
         restartHotkeyMonitoring()
     }
 
@@ -1519,6 +1549,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         hotkeyMonitoringErrorMessage = nil
         hotkeyManager.onShortcutEvent = nil
         hotkeyManager.onEscapeKeyPressed = nil
+        hotkeyManager.onMouseButtonEvent = nil
         hotkeyManager.stop()
     }
 
@@ -1555,7 +1586,10 @@ final class AppState: ObservableObject, @unchecked Sendable {
         }
 
         do {
-            try hotkeyManager.start(configuration: activeShortcutConfiguration)
+            try hotkeyManager.start(
+                configuration: activeShortcutConfiguration,
+                mouseButtonNumber: isMouseDictationEnabled ? mouseDictationButton : nil
+            )
             hotkeyMonitoringErrorMessage = nil
         } catch {
             hotkeyMonitoringErrorMessage = error.localizedDescription
@@ -1593,6 +1627,40 @@ final class AppState: ObservableObject, @unchecked Sendable {
                 pendingShortcutStartMode = .toggle
             }
         }
+    }
+
+    /// Mouse push-to-talk. Down starts a hold session through the exact same
+    /// funnel the keyboard uses (handleShortcutEvent → session controller);
+    /// up ends it. Runs synchronously inside the event-tap callback, so the
+    /// consume decision is made from cheap state checks and the actual
+    /// session work is deferred to the next main-queue turn — mirroring how
+    /// keyboard shortcut events are dispatched.
+    /// Returns true to swallow the click so it never reaches the target app.
+    private func handleMouseDictationButtonEvent(isDown: Bool) -> Bool {
+        if isDown {
+            // A keyboard-triggered session (or in-flight transcription) wins:
+            // let the click through untouched.
+            guard shortcutSessionController.activeMode == nil, !isTranscribing else {
+                return false
+            }
+            isMouseHoldSessionActive = true
+            DispatchQueue.main.async { [weak self] in
+                guard let self, self.isMouseHoldSessionActive else { return }
+                self.handleShortcutEvent(.holdActivated)
+                if self.shortcutSessionController.activeMode != .hold {
+                    self.isMouseHoldSessionActive = false
+                }
+            }
+            return true
+        }
+
+        guard isMouseHoldSessionActive else { return false }
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.isMouseHoldSessionActive else { return }
+            self.isMouseHoldSessionActive = false
+            self.handleShortcutEvent(.holdDeactivated)
+        }
+        return true
     }
 
     private func handleEscapeKeyPress() -> Bool {
@@ -1642,6 +1710,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
 
         cancelPendingShortcutStart()
         shortcutSessionController.reset()
+        isMouseHoldSessionActive = false
         activeRecordingTriggerMode = nil
         audioRecorder.onRecordingReady = nil
         audioRecorder.onRecordingFailure = nil
@@ -1951,6 +2020,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         pendingMicrophonePermissionManualCommandRequested = manualCommandRequested
         hotkeyManager.stop()
         shortcutSessionController.reset()
+        isMouseHoldSessionActive = false
         activeRecordingTriggerMode = nil
         cancelRecordingInitializationTimer()
         audioRecorder.onRecordingReady = nil
@@ -2540,6 +2610,7 @@ final class AppState: ObservableObject, @unchecked Sendable {
         cancelPendingShortcutStart()
         cancelRecordingInitializationTimer()
         shortcutSessionController.reset()
+        isMouseHoldSessionActive = false
         activeRecordingTriggerMode = nil
         let sessionIntent = currentSessionIntent
         let cleanupSessionID = smartCleanupSessionID

--- a/Sources/GlobalShortcutBackend.swift
+++ b/Sources/GlobalShortcutBackend.swift
@@ -21,18 +21,24 @@ final class GlobalShortcutBackend {
     private var eventTap: CFMachPort?
     private var eventTapRunLoopSource: CFRunLoopSource?
     private var fnKeyIsDown = false
+    private var mouseButtonNumber: Int64?
 
     var onInputEvent: ((ShortcutInputEvent) -> ShortcutConsumeDecision)?
     var onEscapeKeyPressed: (() -> Bool)?
+    /// Fired for down/up of the configured non-primary mouse button.
+    /// Return true to consume the click so it never reaches the target app.
+    var onMouseButtonEvent: ((_ isDown: Bool) -> Bool)?
 
-    func start() throws {
+    func start(mouseButtonNumber: Int? = nil) throws {
         stop()
+        self.mouseButtonNumber = mouseButtonNumber.map(Int64.init)
         try installEventTap()
         fnKeyIsDown = ModifierKeyEventState.currentFunctionKeyIsDown()
     }
 
     func stop() {
         tearDownEventTap()
+        mouseButtonNumber = nil
         notifyBackendReset()
     }
 
@@ -41,11 +47,15 @@ final class GlobalShortcutBackend {
     }
 
     private func installEventTap() throws {
-        let eventMask = [
-            CGEventType.flagsChanged,
-            CGEventType.keyDown,
-            CGEventType.keyUp
-        ].reduce(CGEventMask(0)) { partialResult, eventType in
+        var eventTypes: [CGEventType] = [
+            .flagsChanged,
+            .keyDown,
+            .keyUp
+        ]
+        if mouseButtonNumber != nil {
+            eventTypes.append(contentsOf: [.otherMouseDown, .otherMouseUp])
+        }
+        let eventMask = eventTypes.reduce(CGEventMask(0)) { partialResult, eventType in
             partialResult | (CGEventMask(1) << eventType.rawValue)
         }
 
@@ -126,6 +136,14 @@ final class GlobalShortcutBackend {
                 shouldConsume = false
             }
 
+            return shouldConsume ? nil : Unmanaged.passUnretained(event)
+
+        case .otherMouseDown, .otherMouseUp:
+            guard let mouseButtonNumber,
+                  event.getIntegerValueField(.mouseEventButtonNumber) == mouseButtonNumber else {
+                return Unmanaged.passUnretained(event)
+            }
+            let shouldConsume = onMouseButtonEvent?(type == .otherMouseDown) ?? false
             return shouldConsume ? nil : Unmanaged.passUnretained(event)
 
         default:

--- a/Sources/HotkeyManager.swift
+++ b/Sources/HotkeyManager.swift
@@ -10,6 +10,9 @@ final class HotkeyManager {
 
     var onShortcutEvent: ((ShortcutEvent) -> Void)?
     var onEscapeKeyPressed: (() -> Bool)?
+    /// Down/up of the configured mouse dictation button. Return true to
+    /// consume the click. Only fired when start(...) received a button.
+    var onMouseButtonEvent: ((_ isDown: Bool) -> Bool)?
 
     var currentPressedModifiers: ShortcutModifiers {
         inputState.currentModifiers
@@ -19,7 +22,7 @@ final class HotkeyManager {
         inputState.hasPressedShortcutInputs(configuration: configuration)
     }
 
-    func start(configuration: ShortcutConfiguration) throws {
+    func start(configuration: ShortcutConfiguration, mouseButtonNumber: Int? = nil) throws {
         stop()
         self.configuration = configuration
         backend.onInputEvent = { [weak self] event in
@@ -28,11 +31,15 @@ final class HotkeyManager {
         backend.onEscapeKeyPressed = { [weak self] in
             self?.onEscapeKeyPressed?() ?? false
         }
+        backend.onMouseButtonEvent = { [weak self] isDown in
+            self?.onMouseButtonEvent?(isDown) ?? false
+        }
         do {
-            try backend.start()
+            try backend.start(mouseButtonNumber: mouseButtonNumber)
         } catch {
             backend.onInputEvent = nil
             backend.onEscapeKeyPressed = nil
+            backend.onMouseButtonEvent = nil
             inputState = ShortcutInputState()
             throw error
         }
@@ -42,6 +49,7 @@ final class HotkeyManager {
         backend.stop()
         backend.onInputEvent = nil
         backend.onEscapeKeyPressed = nil
+        backend.onMouseButtonEvent = nil
         inputState = ShortcutInputState()
     }
 

--- a/Sources/SettingsView.swift
+++ b/Sources/SettingsView.swift
@@ -448,6 +448,9 @@ struct GeneralSettingsView: View {
                 SettingsCard("Dictation Shortcuts", icon: "keyboard.fill") {
                     hotkeySection
                 }
+                SettingsCard("Mouse Dictation", icon: "computermouse.fill") {
+                    mouseDictationSection
+                }
                 SettingsCard("Ask Megaphone", icon: "sparkles") {
                     wakeCommandSection
                 }
@@ -786,6 +789,22 @@ struct GeneralSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+        }
+    }
+
+    // MARK: Mouse Dictation
+
+    private var mouseDictationSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle("Enable mouse dictation", isOn: $appState.isMouseDictationEnabled)
+
+            MouseDictationButtonRow()
+                .disabled(!appState.isMouseDictationEnabled)
+                .opacity(appState.isMouseDictationEnabled ? 1 : 0.5)
+
+            Text("Hold the bound mouse button to dictate and release to stop — push-to-talk for the extra buttons on MMO mice and trackballs. While bound, that button's clicks are swallowed so they never press anything in the app under the cursor. Left and right buttons can't be used.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 

--- a/Sources/ShortcutComponents.swift
+++ b/Sources/ShortcutComponents.swift
@@ -161,6 +161,95 @@ private struct ShortcutPresetRow: View {
     }
 }
 
+/// Shows the bound mouse dictation button and lets the user rebind it by
+/// pressing the desired button while capture is armed. Capture uses a local
+/// NSEvent monitor (the press must land on a window of this app), and the
+/// global tap is suspended meanwhile so the currently bound button cannot
+/// start dictation mid-capture.
+struct MouseDictationButtonRow: View {
+    @EnvironmentObject var appState: AppState
+
+    @State private var isCapturing = false
+    @State private var captureMonitor: Any?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .center, spacing: 10) {
+                HStack(alignment: .center, spacing: 10) {
+                    Image(systemName: "computermouse")
+                        .foregroundStyle(isCapturing ? .blue : .secondary)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(MouseDictationButton.displayName(for: appState.mouseDictationButton))
+                            .font(.system(.body, design: .monospaced).weight(.semibold))
+                            .foregroundStyle(.primary)
+                        Text(isCapturing ? "Waiting for a mouse button…" : "Hold this button to dictate.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer()
+                }
+                .padding(12)
+                .background(isCapturing ? Color.blue.opacity(0.1) : Color(nsColor: .controlBackgroundColor))
+                .cornerRadius(8)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(isCapturing ? Color.blue : Color.clear, lineWidth: 1.5)
+                )
+
+                Button(isCapturing ? "Cancel" : "Change…") {
+                    if isCapturing {
+                        cancelCapture()
+                    } else {
+                        startCapture()
+                    }
+                }
+                .buttonStyle(.bordered)
+            }
+
+            if isCapturing {
+                Label(
+                    "With the pointer over this window, press the mouse button you want. Middle and side buttons only — left and right clicks keep working normally.",
+                    systemImage: "computermouse"
+                )
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.blue)
+            }
+        }
+        .onChange(of: appState.isMouseDictationEnabled) { _, enabled in
+            if !enabled {
+                cancelCapture()
+            }
+        }
+        .onDisappear {
+            cancelCapture()
+        }
+    }
+
+    private func startCapture() {
+        cancelCapture()
+        isCapturing = true
+        appState.suspendHotkeyMonitoringForShortcutCapture()
+        captureMonitor = NSEvent.addLocalMonitorForEvents(matching: .otherMouseDown) { event in
+            guard MouseDictationButton.isBindable(event.buttonNumber) else { return event }
+            appState.mouseDictationButton = event.buttonNumber
+            cancelCapture()
+            return nil
+        }
+    }
+
+    private func cancelCapture() {
+        if let monitor = captureMonitor {
+            NSEvent.removeMonitor(monitor)
+            captureMonitor = nil
+        }
+        guard isCapturing else { return }
+        isCapturing = false
+        appState.resumeHotkeyMonitoringAfterShortcutCapture()
+    }
+}
+
 private struct ShortcutCaptureRow: View {
     let savedBinding: ShortcutBinding?
     let isSelected: Bool

--- a/Sources/ShortcutCore/MouseDictationButton.swift
+++ b/Sources/ShortcutCore/MouseDictationButton.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Rules and labels for binding a mouse button as a hold-to-talk dictation
+/// trigger. Button numbers use NSEvent/CGEvent numbering: 0 = left,
+/// 1 = right, 2 = middle, 3+ = extra buttons (side/thumb buttons on
+/// MMO mice and trackballs).
+enum MouseDictationButton {
+    /// NSEvent button number for the middle button — the lowest bindable one.
+    static let middleButtonNumber = 2
+
+    /// Default binding: the 4th button (first thumb/side button on most mice).
+    static let defaultButtonNumber = 3
+
+    /// Left (0) and right (1) clicks must never trigger dictation; the
+    /// middle button (2) and anything above it is fair game.
+    static func isBindable(_ buttonNumber: Int) -> Bool {
+        buttonNumber >= middleButtonNumber
+    }
+
+    /// Human-readable label using 1-based mouse-button naming
+    /// (NSEvent button 3 is "Button 4").
+    static func displayName(for buttonNumber: Int) -> String {
+        guard isBindable(buttonNumber) else { return "Unsupported button" }
+        if buttonNumber == middleButtonNumber { return "Middle Button" }
+        return "Button \(buttonNumber + 1)"
+    }
+
+    /// Clamps stored/legacy values to a bindable button so a corrupted or
+    /// hand-edited preference can never bind the left or right button.
+    static func normalized(_ buttonNumber: Int) -> Int {
+        isBindable(buttonNumber) ? buttonNumber : defaultButtonNumber
+    }
+}

--- a/Tests/AppContextServiceTests.swift
+++ b/Tests/AppContextServiceTests.swift
@@ -15,6 +15,7 @@ struct AppContextServiceTests {
         TranscriptTidierTests.run()
         DictionaryStoreTests.run()
         WakePhraseMatcherTests.run()
+        MouseDictationButtonTests.run()
         print("MegaphoneTests passed")
     }
 

--- a/Tests/MouseDictationButtonTests.swift
+++ b/Tests/MouseDictationButtonTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+enum MouseDictationButtonTests {
+    static func run() {
+        testPrimaryButtonsAreNeverBindable()
+        testMiddleAndSideButtonsAreBindable()
+        testDisplayNamesUseOneBasedNumbering()
+        testNormalizationRepairsInvalidStoredValues()
+        testDefaultIsTheFourthButton()
+    }
+
+    private static func testPrimaryButtonsAreNeverBindable() {
+        expect(!MouseDictationButton.isBindable(0), "Left click must never be bindable")
+        expect(!MouseDictationButton.isBindable(1), "Right click must never be bindable")
+        expect(!MouseDictationButton.isBindable(-1), "Negative button numbers must be rejected")
+    }
+
+    private static func testMiddleAndSideButtonsAreBindable() {
+        for buttonNumber in [2, 3, 4, 5, 15] {
+            expect(
+                MouseDictationButton.isBindable(buttonNumber),
+                "Button number \(buttonNumber) should be bindable"
+            )
+        }
+    }
+
+    private static func testDisplayNamesUseOneBasedNumbering() {
+        expectEqual(MouseDictationButton.displayName(for: 2), "Middle Button")
+        expectEqual(MouseDictationButton.displayName(for: 3), "Button 4")
+        expectEqual(MouseDictationButton.displayName(for: 4), "Button 5")
+        expectEqual(MouseDictationButton.displayName(for: 9), "Button 10")
+        expectEqual(MouseDictationButton.displayName(for: 0), "Unsupported button")
+        expectEqual(MouseDictationButton.displayName(for: 1), "Unsupported button")
+    }
+
+    private static func testNormalizationRepairsInvalidStoredValues() {
+        expectEqual(MouseDictationButton.normalized(0), MouseDictationButton.defaultButtonNumber)
+        expectEqual(MouseDictationButton.normalized(1), MouseDictationButton.defaultButtonNumber)
+        expectEqual(MouseDictationButton.normalized(-7), MouseDictationButton.defaultButtonNumber)
+        expectEqual(MouseDictationButton.normalized(2), 2)
+        expectEqual(MouseDictationButton.normalized(6), 6)
+    }
+
+    private static func testDefaultIsTheFourthButton() {
+        expectEqual(MouseDictationButton.defaultButtonNumber, 3)
+        expect(
+            MouseDictationButton.isBindable(MouseDictationButton.defaultButtonNumber),
+            "The default button must itself be bindable"
+        )
+    }
+
+    private static func expectEqual<T: Equatable>(
+        _ actual: T,
+        _ expected: T,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        expect(actual == expected, "Expected \(expected), got \(actual)", file: file, line: line)
+    }
+
+    private static func expect(
+        _ condition: Bool,
+        _ message: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        if !condition {
+            fatalError("\(file):\(line): \(message)")
+        }
+    }
+}


### PR DESCRIPTION
Bind a non-primary mouse button as a hold-to-talk trigger (off by default).

- Extends the existing CGEvent tap (mask includes `.otherMouseDown/Up` only when enabled — zero overhead when off), so the bound click is actually consumed and never reaches the app under the cursor; down/up consumption stays paired.
- Session wiring injects `.holdActivated`/`.holdDeactivated` into the existing keyboard funnel — no parallel dictation path; ignored while a keyboard session or transcription is active; consume decision is cheap/synchronous inside the tap, session work deferred to the main queue (watchdog-safe).
- Bindable buttons: middle and above; left/right rejected at capture. Capture row suspends the global tap while recording, matching keyboard capture.
- Settings: "Mouse Dictation" card (toggle + capture row), keys `mouse_dictation_enabled` / `mouse_dictation_button`.

Verified on macOS 26.5 (arm64): `make test` passes, full build clean. Manual QA checklist in comments below is worth running — event taps can't be unit-tested.

Conflicts: touches `GlobalShortcutBackend`/`HotkeyManager` alongside #rebindable-cancel.
---
*All eight feature PRs register tests in `Tests/AppContextServiceTests.swift` and some extend the Makefile test list, so each merge after the first needs a trivial conflict resolution there. Suggested merge order: dictionary-ranking → formality-dial → caret-context → transforms → scratch-that → raw-undo → rebindable-cancel → mouse-ptt.*
