### PR TITLE
fix: reject smart cleanup output that drops the spoken transcript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,14 +104,14 @@ endif
 test: $(TEST_RUNNER)
 	@$(TEST_RUNNER)
 
-$(TEST_RUNNER): Sources/AppContextService.swift Sources/AppleFoundationModelsPostProcessor.swift Sources/DictionaryStore.swift Sources/TranscriptTidier.swift Sources/TransformStore.swift Sources/WakePhraseMatcher.swift Tests/AppContextServiceTests.swift Tests/DictionaryStoreTests.swift Tests/TranscriptTidierTests.swift Tests/TransformStoreTests.swift Tests/WakePhraseMatcherTests.swift Sources/ScratchCommandMatcher.swift Tests/ScratchCommandMatcherTests.swift Sources/RawRevertEligibility.swift Tests/RawRevertEligibilityTests.swift Sources/ShortcutCore/ShortcutModels.swift Tests/ShortcutCancelBindingTests.swift Sources/ShortcutCore/MouseDictationButton.swift Tests/MouseDictationButtonTests.swift
+$(TEST_RUNNER): Sources/AppContextService.swift Sources/AppleFoundationModelsPostProcessor.swift Sources/DictionaryStore.swift Sources/TranscriptTidier.swift Sources/TransformStore.swift Sources/WakePhraseMatcher.swift Tests/AppContextServiceTests.swift Tests/DictionaryStoreTests.swift Tests/TranscriptTidierTests.swift Tests/TransformStoreTests.swift Tests/WakePhraseMatcherTests.swift Sources/ScratchCommandMatcher.swift Tests/ScratchCommandMatcherTests.swift Sources/RawRevertEligibility.swift Tests/RawRevertEligibilityTests.swift Sources/ShortcutCore/ShortcutModels.swift Tests/ShortcutCancelBindingTests.swift Sources/ShortcutCore/MouseDictationButton.swift Tests/MouseDictationButtonTests.swift Tests/SmartCleanupValidationTests.swift
 	@mkdir -p "$(BUILD_DIR)"
 	swiftc \
 		-parse-as-library \
 		-o "$(TEST_RUNNER)" \
 		-sdk $(shell xcrun --show-sdk-path) \
 		-target $(ARCH)-apple-macosx26.0 \
-		Sources/AppContextService.swift Sources/AppleFoundationModelsPostProcessor.swift Sources/DictionaryStore.swift Sources/TranscriptTidier.swift Sources/TransformStore.swift Sources/WakePhraseMatcher.swift Tests/AppContextServiceTests.swift Tests/DictionaryStoreTests.swift Tests/TranscriptTidierTests.swift Tests/TransformStoreTests.swift Tests/WakePhraseMatcherTests.swift Sources/ScratchCommandMatcher.swift Tests/ScratchCommandMatcherTests.swift Sources/RawRevertEligibility.swift Tests/RawRevertEligibilityTests.swift Sources/ShortcutCore/ShortcutModels.swift Tests/ShortcutCancelBindingTests.swift Sources/ShortcutCore/MouseDictationButton.swift Tests/MouseDictationButtonTests.swift
+		Sources/AppContextService.swift Sources/AppleFoundationModelsPostProcessor.swift Sources/DictionaryStore.swift Sources/TranscriptTidier.swift Sources/TransformStore.swift Sources/WakePhraseMatcher.swift Tests/AppContextServiceTests.swift Tests/DictionaryStoreTests.swift Tests/TranscriptTidierTests.swift Tests/TransformStoreTests.swift Tests/WakePhraseMatcherTests.swift Sources/ScratchCommandMatcher.swift Tests/ScratchCommandMatcherTests.swift Sources/RawRevertEligibility.swift Tests/RawRevertEligibilityTests.swift Sources/ShortcutCore/ShortcutModels.swift Tests/ShortcutCancelBindingTests.swift Sources/ShortcutCore/MouseDictationButton.swift Tests/MouseDictationButtonTests.swift Tests/SmartCleanupValidationTests.swift
 
 icon: $(ICON_ICNS)
 

--- a/Sources/AppleFoundationModelsPostProcessor.swift
+++ b/Sources/AppleFoundationModelsPostProcessor.swift
@@ -836,7 +836,7 @@ actor AppleFoundationModelsPostProcessor {
         return !".!?…".contains(last)
     }
 
-    private static func validate(_ output: String, source: String, allowsExpansion: Bool = false) throws {
+    static func validate(_ output: String, source: String, allowsExpansion: Bool = false) throws {
         guard !output.isEmpty else { throw SmartCleanupError.emptyOutput }
         let lower = output.lowercased()
         let rejectedPrefixes = [
@@ -850,6 +850,48 @@ actor AppleFoundationModelsPostProcessor {
         if !allowsExpansion && output.count > max(sourceCount * 2, sourceCount + 200) {
             throw SmartCleanupError.invalidOutput("unexpectedly expanded the transcript")
         }
+        if !allowsExpansion && output.count * 2 < sourceCount {
+            throw SmartCleanupError.invalidOutput("dropped most of the transcript")
+        }
+        if !allowsExpansion {
+            let dropped = Self.words(source)
+                .intersection(Self.mustPreserveTerms)
+                .subtracting(Self.words(output))
+            if let word = dropped.sorted().first {
+                throw SmartCleanupError.invalidOutput("dropped the spoken word \"\(word)\"")
+            }
+        }
+        // Bullets and numbered lists are welcome, but the model also wraps plain prose in
+        // code fences, headings, or blockquotes, which is never what was dictated.
+        if !allowsExpansion {
+            let lowerSource = source.lowercased()
+            let askedForBlock = ["code block", "code fence", "heading", "quote", "markdown"]
+                .contains { lowerSource.contains($0) }
+            let trimmedOutput = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmedSource = source.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !askedForBlock {
+                let markers = ["```", "> ", "#"]
+                if let marker = markers.first(where: { trimmedOutput.hasPrefix($0) }),
+                   !trimmedSource.hasPrefix(marker) {
+                    throw SmartCleanupError.invalidOutput("wrapped the transcript in markdown")
+                }
+            }
+        }
+    }
+
+    /// Words the model must never silently delete. The system prompt already tells it to
+    /// preserve profanity, but the on-device model drops or paraphrases around these anyway;
+    /// this enforces that contract so the transcript falls back to basic cleanup instead.
+    private static let mustPreserveTerms: Set<String> = [
+        "fuck", "fucks", "fucked", "fucker", "fuckers", "fucking",
+        "shit", "shits", "shitty", "bullshit", "damn", "goddamn", "damned",
+        "ass", "asshole", "arse", "bitch", "bastard", "crap", "piss", "pissed",
+        "dick", "cock", "cunt", "prick", "twat", "wanker", "bollocks", "bugger",
+        "slut", "whore", "douche", "jackass", "dumbass", "motherfucker"
+    ]
+
+    private static func words(_ text: String) -> Set<String> {
+        Set(text.lowercased().split(whereSeparator: { !$0.isLetter }).map(String.init))
     }
 }
 

--- a/Tests/AppContextServiceTests.swift
+++ b/Tests/AppContextServiceTests.swift
@@ -28,6 +28,7 @@ struct AppContextServiceTests {
         RawRevertEligibilityTests.run()
         ShortcutCancelBindingTests.run()
         MouseDictationButtonTests.run()
+        SmartCleanupValidationTests.run()
         print("MegaphoneTests passed")
     }
 

--- a/Tests/SmartCleanupValidationTests.swift
+++ b/Tests/SmartCleanupValidationTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+enum SmartCleanupValidationTests {
+    static func run() {
+        testSpokenProfanitySurvives()
+        testTruncatedTranscriptIsRejected()
+        testOrdinaryCleanupIsAccepted()
+        testListFormattingIsAllowed()
+        testBlockMarkdownIsRejected()
+        testSelectionTransformsAreUnaffected()
+    }
+
+    /// The on-device model sometimes truncates at, or paraphrases around, profanity even
+    /// though the system prompt asks it to preserve it. Falling back to basic cleanup keeps
+    /// the speaker's words instead of silently censoring them.
+    private static func testSpokenProfanitySurvives() {
+        expectRejected("What", source: "What the fuck?")
+        expectRejected("I think we should ship this.", source: "What the fuck?")
+        expectRejected("This is nonsense and I'm annoyed.", source: "This is bullshit and I'm pissed")
+
+        expectAccepted("What the fuck?", source: "What the fuck?")
+        expectAccepted("What the fuck, man.", source: "what the fuck man")
+        expectAccepted("This is bullshit and I'm pissed.", source: "this is bullshit and I'm pissed")
+    }
+
+    private static func testTruncatedTranscriptIsRejected() {
+        expectRejected(
+            "Let's ship.",
+            source: "Let's ship the release on Wednesday once the build finishes and QA signs off."
+        )
+    }
+
+    private static func testOrdinaryCleanupIsAccepted() {
+        expectAccepted("I think we should ship it.", source: "um so I think we should uh ship it you know")
+        expectAccepted(
+            "Let's meet Wednesday after lunch.",
+            source: "let's meet Thursday no actually Wednesday after lunch"
+        )
+        expectAccepted("Is this working properly now?", source: "Is this working properly now?")
+    }
+
+    private static func testListFormattingIsAllowed() {
+        expectAccepted("- option one\n- option two", source: "Give me the two options.")
+        expectAccepted("1. First\n2. Second", source: "What are the steps?")
+    }
+
+    /// Bullets are fine, but fencing or heading plain dictated prose never is.
+    private static func testBlockMarkdownIsRejected() {
+        expectRejected("```\nShip the build.\n```", source: "Ship the build.")
+        expectRejected("# Ship the build.", source: "Ship the build.")
+        expectRejected("> Ship the build.", source: "Ship the build.")
+
+        expectAccepted(
+            "```\nwrap the next line in a code block\n```",
+            source: "wrap the next line in a code block"
+        )
+    }
+
+    /// Selection rewrites legitimately shorten, expand, or reword text on request.
+    private static func testSelectionTransformsAreUnaffected() {
+        expectAccepted("Short.", source: "A much longer sentence that the user asked to shorten.", allowsExpansion: true)
+        expectAccepted("Please review this.", source: "review this damn thing", allowsExpansion: true)
+    }
+
+    private static func expectRejected(
+        _ output: String,
+        source: String,
+        allowsExpansion: Bool = false,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        expect(
+            !accepts(output, source: source, allowsExpansion: allowsExpansion),
+            "Expected \(output.debugDescription) to be rejected for source \(source.debugDescription)",
+            file: file,
+            line: line
+        )
+    }
+
+    private static func expectAccepted(
+        _ output: String,
+        source: String,
+        allowsExpansion: Bool = false,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        expect(
+            accepts(output, source: source, allowsExpansion: allowsExpansion),
+            "Expected \(output.debugDescription) to be accepted for source \(source.debugDescription)",
+            file: file,
+            line: line
+        )
+    }
+
+    private static func accepts(_ output: String, source: String, allowsExpansion: Bool) -> Bool {
+        do {
+            try AppleFoundationModelsPostProcessor.validate(
+                output,
+                source: source,
+                allowsExpansion: allowsExpansion
+            )
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    private static func expect(_ condition: Bool, _ message: String, file: StaticString = #file, line: UInt = #line) {
+        if !condition {
+            fatalError("\(file):\(line): \(message)")
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`validate()` only guards against the model **adding** text:

```swift
if !allowsExpansion && output.count > max(sourceCount * 2, sourceCount + 200) {
    throw SmartCleanupError.invalidOutput("unexpectedly expanded the transcript")
}
```

Nothing guards against it **removing** text. When the on-device model declines to reproduce part of a transcript, the truncated result passes validation and is reported as a success, so the user silently gets words they never said — or loses words they did.

Real entries from `PipelineHistory` on 1.1.8 (macOS 26, Apple silicon), all logged as `Smart on-device cleanup succeeded`:

| Spoken | Pasted |
| --- | --- |
| `What the fuck?` | `What` |
| `What the fuck?` | `I think we should ship this.` |
| `It actually seems really good, but can you check...` | same text wrapped in a ``` fence |

The first two are the notable ones: `SystemLanguageModel` is already constructed with `guardrails: .permissiveContentTransformations`, but the model still truncates at profanity or paraphrases around it, despite the system prompt's explicit instruction to `Preserve language, names, technical identifiers, paths, flags, URLs, and profanity.` Because the output is shorter than the input, nothing caught it.

## Change

Three additional checks in `validate()`, all gated on `!allowsExpansion` so selection transforms (shorten/reword) are unaffected:

1. **Truncation** — reject when the output loses more than half the transcript.
2. **Must-preserve terms** — reject when profanity present in the source is absent from the output, enforcing the contract the system prompt already states.
3. **Block markdown** — reject a leading ```` ``` ````, `#`, or `> ` that the source did not have, unless the speaker asked for a code block/heading/quote.

Bullets and numbered lists are deliberately **not** rejected — auto-list formatting seems desirable, and the prompt already permits it when requested.

A rejection is not a failure: it falls through to `deterministicCleanup`, which reproduces the speaker's words verbatim. On the samples above, that path already produced correct output.

`validate` changed from `private static` to `static` so tests can reach it, matching `commandPrompt` and friends.

## Tests

New `Tests/SmartCleanupValidationTests.swift`, registered in the runner and the `Makefile`, covering the logged regressions plus the cases that must keep passing: filler removal, self-corrections, punctuation fixes, auto bullets/numbered lists, preserved profanity, and `allowsExpansion` transforms.

`make test` passes.

## Notes

- The threshold for check 1 is deliberately loose (50%) to avoid rejecting legitimate filler removal and self-corrections. It therefore does not catch smaller losses — e.g. `This seems really fast. I think I might switch to this.` → `- I think I might switch to this` still passes. Tightening it safely probably needs filler-aware content-word retention rather than a character ratio; happy to follow up if you want that.
- The term list in `mustPreserveTerms` is English-only and intentionally short. Easy to extend, though a broader list raises the cost of a false rejection (a needlessly basic-cleaned transcript).
